### PR TITLE
[action] Cache QT install files

### DIFF
--- a/.github/workflows/win-cpn-32.yml
+++ b/.github/workflows/win-cpn-32.yml
@@ -65,10 +65,18 @@ jobs:
                                 mingw-w64-i686-clang \
                                 mingw-w64-i686-nsis
           pip install Pillow clang
-          
+
+      - name: Cache Qt
+        id: cache-qt
+        uses: actions/cache@v1  # not v2!
+        with:
+          path: ../Qt
+          key: ${{ runner.os }}-QtCache
+
       - name: Install Qt
         uses: jurplel/install-qt-action@v2
         with:
+          cached: ${{ steps.cache-qt.outputs.cache-hit }}
           version: ${{ env.QT_VERSION }}
           arch: ${{ env.MINGW_VERSION }}
 

--- a/.github/workflows/win-cpn-32.yml
+++ b/.github/workflows/win-cpn-32.yml
@@ -71,7 +71,7 @@ jobs:
         uses: actions/cache@v1  # not v2!
         with:
           path: ../Qt
-          key: ${{ runner.os }}-QtCache
+          key: win32-QtCache
 
       - name: Install Qt
         uses: jurplel/install-qt-action@v2

--- a/.github/workflows/win_cpn.yml
+++ b/.github/workflows/win_cpn.yml
@@ -68,10 +68,18 @@ jobs:
                                 mingw-w64-x86_64-clang \
                                 mingw-w64-x86_64-nsis
           pip install Pillow clang
-          
+
+      - name: Cache Qt
+        id: cache-qt
+        uses: actions/cache@v1  # not v2!
+        with:
+          path: ../Qt
+          key: ${{ runner.os }}-QtCache
+
       - name: Install Qt
         uses: jurplel/install-qt-action@v2
         with:
+          cached: ${{ steps.cache-qt.outputs.cache-hit }}
           version: ${{ env.QT_VERSION }}
           arch: ${{ env.MINGW_VERSION }}
 

--- a/.github/workflows/win_cpn.yml
+++ b/.github/workflows/win_cpn.yml
@@ -74,7 +74,7 @@ jobs:
         uses: actions/cache@v1  # not v2!
         with:
           path: ../Qt
-          key: ${{ runner.os }}-QtCache
+          key: win64-QtCache
 
       - name: Install Qt
         uses: jurplel/install-qt-action@v2


### PR DESCRIPTION
Summary of changes:
- enable caching for QT install for Windows actions, which should mitigate the download failures causing the actions to fail periodically
