### PR TITLE
fix: Add git 2.35.2 and later workaround for CVE-2022-24765 change

### DIFF
--- a/tools/build-gh.sh
+++ b/tools/build-gh.sh
@@ -74,11 +74,13 @@ COMMON_OPTIONS+=${EXTRA_OPTIONS}
 
 : "${FIRMARE_TARGET:="firmware-size"}"
 
+# workaround for GH repo owner
+git config --global --add safe.directory "$(pwd)"
+
 # wipe build directory clean
 rm -rf build && mkdir -p build && cd build
 
 GIT_SHA_SHORT=$(git rev-parse --short HEAD)
-#GIT_TAG=`git describe --tags`
 
 target_names=$(echo "$FLAVOR" | tr '[:upper:]' '[:lower:]' | tr ';' '\n')
 


### PR DESCRIPTION
<!-- 
Please note that pull requests are NOT an appropriate way to
ask questions or for support, and will be closed. 

For feature requests or bug reports, please use the Issues tab.
For support, please use the Discussion tab or join us on Discord.

Feel free to delete any of the below which does not apply.
-->

Fixes #

Summary of changes:
