### PR TITLE
chore(github): Update QT install action to use internal cache

### DIFF
--- a/.github/workflows/win-cpn-32.yml
+++ b/.github/workflows/win-cpn-32.yml
@@ -68,17 +68,11 @@ jobs:
                                 mingw-w64-i686-nsis
           python -m pip install clang
 
-      - name: Cache Qt
-        id: cache-qt
-        uses: actions/cache@v1  # not v2!
-        with:
-          path: ../Qt
-          key: win32-QtCache
-
       - name: Install Qt
-        uses: jurplel/install-qt-action@v2
+        uses: jurplel/install-qt-action@v3
         with:
-          cached: ${{ steps.cache-qt.outputs.cache-hit }}
+          cached: true
+          cache-key-prefix: 'win32-QtCache'
           version: ${{ env.QT_VERSION }}
           arch: ${{ env.MINGW_VERSION }}
 

--- a/.github/workflows/win_cpn-64.yml
+++ b/.github/workflows/win_cpn-64.yml
@@ -72,10 +72,10 @@ jobs:
           python -m pip install clang
 
       - name: Install Qt
-        uses: jurplel/install-qt-action@96e5ea1bad2afbc4278b37752897e32486b890bf
+        uses: jurplel/install-qt-action@02bf21af0bd9c98e9423bf392b17a3cc2cf2d84f
         with:
           cache: true
-          cache-key-prefix: 'win64-QtCache-96e5ea1'
+          cache-key-prefix: 'win64-QtCache'
           version: ${{ env.QT_VERSION }}
           arch: ${{ env.MINGW_VERSION }}
 

--- a/.github/workflows/win_cpn-64.yml
+++ b/.github/workflows/win_cpn-64.yml
@@ -72,7 +72,7 @@ jobs:
           python -m pip install clang
 
       - name: Install Qt
-        uses: jurplel/install-qt-action
+        uses: jurplel/install-qt-action@master
         with:
           cached: true
           cache-key-prefix: 'win64-QtCache'

--- a/.github/workflows/win_cpn-64.yml
+++ b/.github/workflows/win_cpn-64.yml
@@ -72,9 +72,9 @@ jobs:
           python -m pip install clang
 
       - name: Install Qt
-        uses: jurplel/install-qt-action@master
+        uses: jurplel/install-qt-action@96e5ea1
         with:
-          cached: true
+          cache: true
           cache-key-prefix: 'win64-QtCache'
           version: ${{ env.QT_VERSION }}
           arch: ${{ env.MINGW_VERSION }}

--- a/.github/workflows/win_cpn-64.yml
+++ b/.github/workflows/win_cpn-64.yml
@@ -72,7 +72,7 @@ jobs:
           python -m pip install clang
 
       - name: Install Qt
-        uses: jurplel/install-qt-action@96e5ea1
+        uses: jurplel/install-qt-action@96e5ea1bad2afbc4278b37752897e32486b890bf
         with:
           cache: true
           cache-key-prefix: 'win64-QtCache'

--- a/.github/workflows/win_cpn-64.yml
+++ b/.github/workflows/win_cpn-64.yml
@@ -75,12 +75,12 @@ jobs:
         uses: jurplel/install-qt-action@96e5ea1bad2afbc4278b37752897e32486b890bf
         with:
           cache: true
-          cache-key-prefix: 'win64-QtCache'
+          cache-key-prefix: 'win64-QtCache-96e5ea1'
           version: ${{ env.QT_VERSION }}
           arch: ${{ env.MINGW_VERSION }}
 
       - name: Check out the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: recursive
 
@@ -97,7 +97,7 @@ jobs:
         run: echo "artifact_name=edgetx-cpn-win64-${GITHUB_REF##*/}" >> $GITHUB_ENV
 
       - name: Archive production artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: "${{ env.artifact_name }}"
           path:  ${{github.workspace}}/output

--- a/.github/workflows/win_cpn-64.yml
+++ b/.github/workflows/win_cpn-64.yml
@@ -71,17 +71,11 @@ jobs:
                                 mingw-w64-x86_64-nsis
           python -m pip install clang
 
-      - name: Cache Qt
-        id: cache-qt
-        uses: actions/cache@v1  # not v2!
-        with:
-          path: ../Qt
-          key: win64-QtCache
-
       - name: Install Qt
-        uses: jurplel/install-qt-action@v2
+        uses: jurplel/install-qt-action@v3
         with:
-          cached: ${{ steps.cache-qt.outputs.cache-hit }}
+          cached: true
+          cache-key-prefix: 'win64-QtCache'
           version: ${{ env.QT_VERSION }}
           arch: ${{ env.MINGW_VERSION }}
 

--- a/.github/workflows/win_cpn-64.yml
+++ b/.github/workflows/win_cpn-64.yml
@@ -72,7 +72,7 @@ jobs:
           python -m pip install clang
 
       - name: Install Qt
-        uses: jurplel/install-qt-action@v3
+        uses: jurplel/install-qt-action
         with:
           cached: true
           cache-key-prefix: 'win64-QtCache'


### PR DESCRIPTION
v2 of the `install-qt-action` action requires v1 of the `cache` action
which does not support caching manual trigger `workflow_dispatch`
runs (and IIRC schedule triggers also).

Thus meaning the cache was being lost for the 32bit builds since it
would never get a push or PR trigger to keep it from expiring.

v3 supports internal caching, so this commit aims to enable and test it.

<!-- 
Please note that pull requests are NOT an appropriate way to
ask questions or for support, and will be closed. 

For feature requests or bug reports, please use the Issues tab.
For support, please use the Discussion tab or join us on Discord.

Feel free to delete any of the below which does not apply.
-->

Fixes #

Summary of changes:
