### PR TITLE
cpn msys find clang

### DIFF
--- a/.github/workflows/win_cpn-64.yml
+++ b/.github/workflows/win_cpn-64.yml
@@ -23,11 +23,13 @@ on:
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  # use https://ddalcino.github.io/aqt-list-server/ match mingw, qt and aqt versions
   BUILD_TYPE: Release
   CMAKE_GENERATOR: "MSYS Makefiles"
   QT_VERSION: "5.15.2"
   MINGW_VERSION: "win64_mingw81"
   MINGW_PATH: "mingw81_64"
+  AQT_VERSION: "==3.1.*"
 
 jobs:
   build:
@@ -74,8 +76,11 @@ jobs:
         with:
           cache: true
           cache-key-prefix: 'install-qt-action-win64'
+          aqtversion: ${{ env.AQT_VERSION }}
           version: ${{ env.QT_VERSION }}
           arch: ${{ env.MINGW_VERSION }}
+          host: "windows"
+          target: "desktop"
 
       - name: Check out the repo
         uses: actions/checkout@v4

--- a/.github/workflows/win_cpn-64.yml
+++ b/.github/workflows/win_cpn-64.yml
@@ -86,6 +86,7 @@ jobs:
         working-directory: ${{github.workspace}}
         # Execute the build.  You can specify a specific target with "--target <NAME>"
         run: |
+          [[ "${MSYSTEM,,}" == "mingw32" || "${MSYSTEM,,}" == "mingw64" ]] && export PATH="${PATH}:/$(echo "${MSYSTEM}" | tr '[:upper:]' '[:lower:]')/lib"
           echo $PATH
           mkdir output && \
           CMAKE_PREFIX_PATH=$RUNNER_WORKSPACE/Qt/$QT_VERSION/$MINGW_PATH \

--- a/.github/workflows/win_cpn-64.yml
+++ b/.github/workflows/win_cpn-64.yml
@@ -86,6 +86,7 @@ jobs:
         working-directory: ${{github.workspace}}
         # Execute the build.  You can specify a specific target with "--target <NAME>"
         run: |
+          echo $PATH
           mkdir output && \
           CMAKE_PREFIX_PATH=$RUNNER_WORKSPACE/Qt/$QT_VERSION/$MINGW_PATH \
           tools/build-companion.sh "$(pwd)" "$(pwd)/output/"

--- a/radio/util/find_clang.py
+++ b/radio/util/find_clang.py
@@ -80,14 +80,14 @@ def findLibClang():
         knownPaths = os.environ.get("PATH").split(os.pathsep)
         libSuffix = ".dll"
     else:
-        # Unsupported platform
         return None
         
     for path in knownPaths:
         # print("trying " + path)
         if os.path.exists(path + "/libclang" + libSuffix):
             return path
-
+    
+    # If no known path is found
     return None
 
 def initLibClang():
@@ -100,13 +100,16 @@ def initLibClang():
             Config.set_library_path(library_path)
         else:
             Config.set_library_file(library_path)
+    else:
+        print("WARN  (find_clang): no library_path", file=sys.stderr)
 
     Config.set_compatibility_check(False)
 
     try:
         index = Index.create()
     except Exception as e:
-        print("ERROR: could not load libclang from '%s'." % library_path, file=sys.stderr)
+        print("ERROR (find_clang): could not load libclang from '%s'." % library_path, file=sys.stderr)
+        print("                  : detected platform '%s'" % sys.platform, file=sys.stderr)
         return False
 
     global builtin_hdr_path


### PR DESCRIPTION
Fixes #

Summary of changes:
- I have this suspicion the breakage is either due to a version mismatch between the system package and the python package, it seem msys clang package is v18, and python is v17. Or, it could be due to a broken package build in mingw which we're retaining in the main repo due to caching...