### PR TITLE
chore(ci): Python 3.12 no longer comes with setuptools

### DIFF
--- a/.github/workflows/win_cpn-32.yml
+++ b/.github/workflows/win_cpn-32.yml
@@ -37,12 +37,12 @@ jobs:
         with:
           msystem: MINGW32
           update: true
-          install: git make curl tar mingw-w64-i686-toolchain
+          install: git make curl tar mingw-w64-i686-toolchain mingw-w64-i686-python-pip
 
       - name: Install Dependencies
         run: |
+          python -m pip install setuptools
           pacman -S --noconfirm mingw-w64-i686-cmake \
-                                mingw-w64-i686-python-pip \
                                 mingw-w64-i686-python-pillow \
                                 mingw-w64-i686-libjpeg-turbo \
                                 mingw-w64-i686-zlib \


### PR DESCRIPTION
gh-95299: Do not pre-install setuptools in virtual environments created with venv.

<!-- 
Please note that pull requests are NOT an appropriate way to
ask questions or for support, and will be closed. 

For feature requests or bug reports, please use the Issues tab.
For support, please use the Discussion tab or join us on Discord.

Feel free to delete any of the below which does not apply.
-->

Fixes #

Summary of changes:
