### PR TITLE
chore: work around CMake 4.x deprecation of < 3.5 compatibility

### DIFF
--- a/cmake/FetchMaxLibQt.cmake
+++ b/cmake/FetchMaxLibQt.cmake
@@ -5,7 +5,7 @@ include(FetchContent)
 FetchContent_Declare(
   maxLibQt
   GIT_REPOSITORY https://github.com/edgetx/maxLibQt
-  GIT_TAG        90aa19783d65cdfb0fdfceb6b6b3c5d4e37523a0
+  GIT_TAG        4ff912ed9f2ba9cea12c6633fef34028da767a6c
 )
 
 FetchContent_MakeAvailable(maxLibQt)

--- a/cmake/FetchMaxLibQt.cmake
+++ b/cmake/FetchMaxLibQt.cmake
@@ -5,7 +5,7 @@ include(FetchContent)
 FetchContent_Declare(
   maxLibQt
   GIT_REPOSITORY https://github.com/edgetx/maxLibQt
-  GIT_TAG        b5418f76cc4891e09f4e21276175d39dbb130f66
+  GIT_TAG        90aa19783d65cdfb0fdfceb6b6b3c5d4e37523a0
 )
 
 FetchContent_MakeAvailable(maxLibQt)

--- a/cmake/FetchMiniz.cmake
+++ b/cmake/FetchMiniz.cmake
@@ -4,8 +4,8 @@ include(FetchContent)
 
 FetchContent_Declare(
   miniz
-  GIT_REPOSITORY https://github.com/richgel999/miniz
-  GIT_TAG        293d4db1b7d0ffee9756d035b9ac6f7431ef8492 # v3.0.2
+  GIT_REPOSITORY https://github.com/pfeerick/miniz/
+  GIT_TAG        8061c01970016f60eba4e4c563aab09290523878
 )
 
 FetchContent_MakeAvailable(miniz)

--- a/cmake/FetchMiniz.cmake
+++ b/cmake/FetchMiniz.cmake
@@ -4,8 +4,8 @@ include(FetchContent)
 
 FetchContent_Declare(
   miniz
-  GIT_REPOSITORY https://github.com/pfeerick/miniz/
-  GIT_TAG        8061c01970016f60eba4e4c563aab09290523878
+  GIT_REPOSITORY https://github.com/richgel999/miniz
+  GIT_TAG        89d7a5f6c3ce8893ea042b0a9d2a2d9975589ac9
 )
 
 FetchContent_MakeAvailable(miniz)

--- a/cmake/FetchYamlCpp.cmake
+++ b/cmake/FetchYamlCpp.cmake
@@ -4,8 +4,8 @@ include(FetchContent)
 
 FetchContent_Declare(
   yaml-cpp
-  GIT_REPOSITORY https://github.com/jbeder/yaml-cpp
-  GIT_TAG        f7320141120f720aecc4c32be25586e7da9eb978 # v0.8.0
+  GIT_REPOSITORY https://github.com/gruenich/yaml-cpp
+  GIT_TAG        fac0bd8eb5c4972f4284ddebd20c5facb47a32e5
 )
 
 FetchContent_MakeAvailable(yaml-cpp)

--- a/cmake/FetchYamlCpp.cmake
+++ b/cmake/FetchYamlCpp.cmake
@@ -4,8 +4,8 @@ include(FetchContent)
 
 FetchContent_Declare(
   yaml-cpp
-  GIT_REPOSITORY https://github.com/gruenich/yaml-cpp
-  GIT_TAG        fac0bd8eb5c4972f4284ddebd20c5facb47a32e5
+  GIT_REPOSITORY https://github.com/jbeder/yaml-cpp
+  GIT_TAG        28f93bdec6387d42332220afa9558060c8016795
 )
 
 FetchContent_MakeAvailable(yaml-cpp)

--- a/cmake/GenericDefinitions.cmake
+++ b/cmake/GenericDefinitions.cmake
@@ -4,7 +4,7 @@ cmake_policy(SET CMP0020 NEW)
 
 # Allow keyword and plain target_link_libraries() signatures to be mixed
 # https://cmake.org/cmake/help/latest/policy/CMP0023.html
-cmake_policy(SET CMP0023 OLD)
+# cmake_policy(SET CMP0023 OLD)
 
 # Use @rpath in a target's install name on MacOS X for locating shared libraries
 # https://cmake.org/cmake/help/latest/policy/CMP0042.html

--- a/companion/src/CMakeLists.txt
+++ b/companion/src/CMakeLists.txt
@@ -361,9 +361,9 @@ elseif(PCB STREQUAL PL18)
 else()
   string(TOLOWER ${PCB} FLAVOUR)
 endif()
-if(POLICY CMP0026)
-  #cmake_policy(SET CMP0026 OLD)  # https://cmake.org/cmake/help/v3.0/policy/CMP0026.html
-endif()
+#if(POLICY CMP0026)
+#  cmake_policy(SET CMP0026 OLD)  # https://cmake.org/cmake/help/v3.0/policy/CMP0026.html
+#endif()
 
 include(FindDfuutil)
 include(FindLibusb1)

--- a/companion/src/CMakeLists.txt
+++ b/companion/src/CMakeLists.txt
@@ -362,7 +362,7 @@ else()
   string(TOLOWER ${PCB} FLAVOUR)
 endif()
 if(POLICY CMP0026)
-  cmake_policy(SET CMP0026 OLD)  # https://cmake.org/cmake/help/v3.0/policy/CMP0026.html
+  #cmake_policy(SET CMP0026 OLD)  # https://cmake.org/cmake/help/v3.0/policy/CMP0026.html
 endif()
 
 include(FindDfuutil)


### PR DESCRIPTION
<!-- 
Please note that pull requests are NOT an appropriate way to
ask questions or for support, and will be closed. 

For feature requests or bug reports, please use the Issues tab.
For support, please use the Discussion tab or join us on Discord.

Feel free to delete any of the below which does not apply.
-->

Fixes #

Summary of changes:
