### PR TITLE
feat(cpn): build for both x86 and arm64 MacOS

### DIFF
--- a/.github/workflows/macosx_cpn.yml
+++ b/.github/workflows/macosx_cpn.yml
@@ -437,7 +437,7 @@ jobs:
           set(CPACK_PACKAGE_FILE_NAME "${{ env.universal_dmg_name }}")
           set(CPACK_RESOURCE_FILE_LICENSE "${LICENSE_FILE}")
           set(CPACK_DMG_DS_STORE "${DS_STORE_FILE}")
-          install(DIRECTORY "${APP_ESCAPED}" DESTINATION "." COMPONENT Runtime)
+          install(DIRECTORY "${APP_ESCAPED}" DESTINATION "." COMPONENT Runtime USE_SOURCE_PERMISSIONS)
           include(CPack)
           EOF
 

--- a/.github/workflows/macosx_cpn.yml
+++ b/.github/workflows/macosx_cpn.yml
@@ -423,6 +423,12 @@ jobs:
             exit 1
           fi
 
+          UNIVERSAL_APP="/tmp/app-universal/${{ env.app_name }}"
+          if [ ! -d "${UNIVERSAL_APP}" ]; then
+            echo "::error::Universal app not found: ${UNIVERSAL_APP}"
+            exit 1
+          fi
+
           RW_DMG="/tmp/edgetx-universal-template-rw.dmg"
           TEMPLATE_MOUNT="/tmp/dmg-template-universal"
 
@@ -435,6 +441,21 @@ jobs:
           rm -f "${RW_DMG}"
           hdiutil convert "${TEMPLATE_DMG}" -format UDRW -o "${RW_DMG}"
 
+          universal_kb=$(du -sk "${UNIVERSAL_APP}" | awk '{print $1}')
+          required_mb=$(( (universal_kb / 1024) + 2048 ))
+          current_bytes=$(hdiutil imageinfo "${RW_DMG}" | awk -F': *' '/Total Bytes/{print $2}' | awk '{print $1}' | tr -d ',')
+          current_mb=0
+          if [[ "${current_bytes}" =~ ^[0-9]+$ ]]; then
+            current_mb=$(( (current_bytes + 1048575) / 1048576 ))
+          fi
+
+          if [ "${required_mb}" -gt "${current_mb}" ]; then
+            echo "Resizing RW DMG from ${current_mb}MB to ${required_mb}MB for universal app copy"
+            hdiutil resize -size "${required_mb}m" "${RW_DMG}"
+          else
+            echo "RW DMG size ${current_mb}MB is sufficient"
+          fi
+
           mkdir -p "${TEMPLATE_MOUNT}"
           hdiutil attach -nobrowse -readwrite -mountpoint "${TEMPLATE_MOUNT}" "${RW_DMG}"
 
@@ -445,7 +466,7 @@ jobs:
           fi
 
           rm -rf "${TEMPLATE_APP_PATH}"
-          cp -R "/tmp/app-universal/${{ env.app_name }}" "${TEMPLATE_MOUNT}/"
+          cp -R "${UNIVERSAL_APP}" "${TEMPLATE_MOUNT}/"
 
           if [ ! -e "${TEMPLATE_MOUNT}/Applications" ]; then
             ln -s /Applications "${TEMPLATE_MOUNT}/Applications"

--- a/.github/workflows/macosx_cpn.yml
+++ b/.github/workflows/macosx_cpn.yml
@@ -356,6 +356,17 @@ jobs:
             exit 1
           fi
 
+          # Normalize executable bits for packaged app binaries
+          APP_UNIVERSAL_PATH="/tmp/app-universal/${APP_NAME}"
+          if [ -d "${APP_UNIVERSAL_PATH}/Contents/MacOS" ]; then
+            find "${APP_UNIVERSAL_PATH}/Contents/MacOS" -type f -exec chmod 755 {} \;
+          fi
+          find "${APP_UNIVERSAL_PATH}" -type f -print0 | while IFS= read -r -d '' f; do
+            if file "$f" | grep -qE 'Mach-O'; then
+              chmod 755 "$f"
+            fi
+          done
+
           # Persist names for later steps
           VERSION_FAMILY=$(printf '%s' "${APP_NAME}" | sed -E 's/^EdgeTX Companion ([0-9]+\.[0-9]+(\.[0-9]+)?).*\.app$/\1/')
           if [ -z "${VERSION_FAMILY}" ] || [ "${VERSION_FAMILY}" = "${APP_NAME}" ]; then

--- a/.github/workflows/macosx_cpn.yml
+++ b/.github/workflows/macosx_cpn.yml
@@ -413,11 +413,47 @@ jobs:
       - name: Package universal DMG
         shell: bash
         run: |
+          set -euo pipefail
+
           mkdir -p output-universal
-          hdiutil create -volname "${{ env.app_name }}" \
-            -srcfolder /tmp/app-universal \
-            -ov -format UDZO \
-            "output-universal/${{ env.universal_dmg_name }}"
+
+          TEMPLATE_DMG=$(find output-x86_64 -name 'edgetx-companion-*.dmg' -print -quit)
+          if [ -z "${TEMPLATE_DMG}" ]; then
+            echo "::error::Unable to locate x86_64 template DMG for packaging"
+            exit 1
+          fi
+
+          RW_DMG="/tmp/edgetx-universal-template-rw.dmg"
+          TEMPLATE_MOUNT="/tmp/dmg-template-universal"
+
+          cleanup_package() {
+            hdiutil detach "${TEMPLATE_MOUNT}" -quiet 2>/dev/null || true
+            rm -f "${RW_DMG}"
+          }
+          trap cleanup_package EXIT
+
+          rm -f "${RW_DMG}"
+          hdiutil convert "${TEMPLATE_DMG}" -format UDRW -o "${RW_DMG}"
+
+          mkdir -p "${TEMPLATE_MOUNT}"
+          hdiutil attach -nobrowse -readwrite -mountpoint "${TEMPLATE_MOUNT}" "${RW_DMG}"
+
+          TEMPLATE_APP_PATH=$(find "${TEMPLATE_MOUNT}" -maxdepth 1 -name '*.app' -type d -print -quit)
+          if [ -z "${TEMPLATE_APP_PATH}" ]; then
+            echo "::error::Template DMG does not contain an .app at root"
+            exit 1
+          fi
+
+          rm -rf "${TEMPLATE_APP_PATH}"
+          cp -R "/tmp/app-universal/${{ env.app_name }}" "${TEMPLATE_MOUNT}/"
+
+          if [ ! -e "${TEMPLATE_MOUNT}/Applications" ]; then
+            ln -s /Applications "${TEMPLATE_MOUNT}/Applications"
+          fi
+
+          hdiutil detach "${TEMPLATE_MOUNT}" -quiet
+
+          hdiutil convert "${RW_DMG}" -format UDZO -o "output-universal/${{ env.universal_dmg_name }}"
 
       - name: Archive universal artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/macosx_cpn.yml
+++ b/.github/workflows/macosx_cpn.yml
@@ -146,45 +146,39 @@ jobs:
       - name: Create universal binaries with lipo
         shell: bash
         run: |
-          mkdir -p output-universal
+          mkdir -p /tmp/app-universal
 
-          # Find all .app bundles in the x86_64 output and process them
-          find output-x86_64 -name "*.app" -type d | while read app_x86; do
-            app_name=$(basename "$app_x86")
-            app_arm="output-arm64/${app_name}"
-            app_out="output-universal/${app_name}"
+          # Mount both DMGs
+          hdiutil attach output-x86_64/edgetx-companion-*.dmg -mountpoint /tmp/dmg-x86_64 -nobrowse -quiet
+          hdiutil attach output-arm64/edgetx-companion-*.dmg -mountpoint /tmp/dmg-arm64 -nobrowse -quiet
 
-            if [ ! -d "$app_arm" ]; then
-              echo "Warning: No arm64 counterpart for $app_name, copying x86_64 only"
-              cp -R "$app_x86" "$app_out"
-              continue
-            fi
+          # Get app name from mounted volume
+          APP_NAME=$(ls /tmp/dmg-x86_64/ | grep "\.app$" | head -1)
 
-            # Copy the x86_64 app as a base (preserves structure, plists, resources)
-            cp -R "$app_x86" "$app_out"
+          # Copy x86_64 app as base
+          cp -R "/tmp/dmg-x86_64/${APP_NAME}" /tmp/app-universal/
 
-            # Find all Mach-O executables/dylibs in the app and lipo them
-            find "$app_x86" -type f | while read f_x86; do
-              rel="${f_x86#$app_x86/}"
-              f_arm="$app_arm/$rel"
-              f_out="$app_out/$rel"
+          # Lipo all Mach-O files
+          find "/tmp/dmg-x86_64/${APP_NAME}" -type f | while read f_x86; do
+            rel="${f_x86#/tmp/dmg-x86_64/${APP_NAME}/}"
+            f_arm="/tmp/dmg-arm64/${APP_NAME}/${rel}"
+            f_out="/tmp/app-universal/${APP_NAME}/${rel}"
 
-              if [ -f "$f_arm" ] && file "$f_x86" | grep -qE 'Mach-O'; then
-                lipo -create "$f_x86" "$f_arm" -output "$f_out"
-              fi
-            done
-          done
-
-          # Handle any loose binaries/dmg/zip files that aren't .app bundles
-          find output-x86_64 -maxdepth 1 -not -name "*.app" -type f | while read f_x86; do
-            fname=$(basename "$f_x86")
-            f_arm="output-arm64/$fname"
             if [ -f "$f_arm" ] && file "$f_x86" | grep -qE 'Mach-O'; then
-              lipo -create "$f_x86" "$f_arm" -output "output-universal/$fname"
-            elif [ -f "$f_arm" ]; then
-              cp "$f_x86" "output-universal/$fname"
+              lipo -create "$f_x86" "$f_arm" -output "$f_out"
             fi
           done
+
+          # Detach DMGs
+          hdiutil detach /tmp/dmg-x86_64 -quiet
+          hdiutil detach /tmp/dmg-arm64 -quiet
+
+          # Get version from DMG filename for output naming
+          DMG_NAME=$(ls output-x86_64/edgetx-companion-*.dmg | xargs basename | sed 's/\.dmg/-universal.dmg/')
+          hdiutil create -volname "${APP_NAME%.app}" \
+            -srcfolder /tmp/app-universal \
+            -ov -format UDZO \
+            "output-universal/${DMG_NAME}"
 
       - name: Ad-hoc code sign universal binaries
         shell: bash

--- a/.github/workflows/macosx_cpn.yml
+++ b/.github/workflows/macosx_cpn.yml
@@ -395,10 +395,18 @@ jobs:
 
           CPACK_PROJECT_DIR="/tmp/universal-dmg-cpack"
           CPACK_OUTPUT_DIR="/tmp/universal-dmg-output"
+          VERIFY_MOUNT="/tmp/dmg-universal-verify"
           rm -rf "${CPACK_PROJECT_DIR}"
           rm -rf "${CPACK_OUTPUT_DIR}"
+          rm -rf "${VERIFY_MOUNT}"
           mkdir -p "${CPACK_PROJECT_DIR}"
           mkdir -p "${CPACK_OUTPUT_DIR}"
+          mkdir -p "${VERIFY_MOUNT}"
+
+          cleanup_package_verify() {
+            hdiutil detach "${VERIFY_MOUNT}" -quiet 2>/dev/null || true
+          }
+          trap cleanup_package_verify EXIT
 
           APP_ESCAPED="${UNIVERSAL_APP//\"/\\\"}"
           LICENSE_FILE="${GITHUB_WORKSPACE}/LICENSE"
@@ -426,6 +434,30 @@ jobs:
             find "${CPACK_OUTPUT_DIR}" -maxdepth 4 -print || true
             exit 1
           fi
+
+          echo "Verifying app signature inside packaged DMG"
+          hdiutil attach -nobrowse -readonly -noautoopen -mountpoint "${VERIFY_MOUNT}" "${DMG_FILE}"
+          DMG_APP_PATH=$(find "${VERIFY_MOUNT}" -maxdepth 1 -name '*.app' -type d -print -quit)
+          if [ -z "${DMG_APP_PATH}" ]; then
+            echo "::error::No .app found in packaged DMG"
+            ls -la "${VERIFY_MOUNT}" || true
+            exit 1
+          fi
+
+          if ! codesign --verify --deep --strict --verbose=2 "${DMG_APP_PATH}"; then
+            echo "::error::Codesign verification failed for app inside DMG"
+            echo "App path: ${DMG_APP_PATH}"
+            find "${DMG_APP_PATH}/Contents" -type f | while read f; do
+              if file "$f" | grep -qE 'Mach-O'; then
+                echo "=== $f ==="
+                lipo -info "$f" || true
+                codesign -dv --verbose=4 "$f" 2>&1 || true
+              fi
+            done
+            exit 1
+          fi
+
+          hdiutil detach "${VERIFY_MOUNT}" -quiet
 
           cp "${DMG_FILE}" output-universal/
 

--- a/.github/workflows/macosx_cpn.yml
+++ b/.github/workflows/macosx_cpn.yml
@@ -256,8 +256,22 @@ jobs:
           echo "arm64 DMG: ${ARM_DMG}"
 
           # Mount both DMGs
-          hdiutil attach "${X86_DMG}" -mountpoint /tmp/dmg-x86_64 -nobrowse
-          hdiutil attach "${ARM_DMG}" -mountpoint /tmp/dmg-arm64 -nobrowse
+          attach_dmg() {
+            local dmg_path="$1"
+            local mount_point="$2"
+            local label="$3"
+
+            echo "Attaching ${label} DMG at ${mount_point}"
+            if ! hdiutil attach "${dmg_path}" -mountpoint "${mount_point}" -nobrowse -readonly -acceptlicense; then
+              echo "::error::Failed to attach ${label} DMG: ${dmg_path}"
+              echo "${label} DMG imageinfo:"
+              hdiutil imageinfo "${dmg_path}" || true
+              exit 1
+            fi
+          }
+
+          attach_dmg "${X86_DMG}" /tmp/dmg-x86_64 x86_64
+          attach_dmg "${ARM_DMG}" /tmp/dmg-arm64 arm64
 
           echo "Mounted x86_64 DMG:" && ls -la /tmp/dmg-x86_64
           echo "Mounted arm64 DMG:" && ls -la /tmp/dmg-arm64

--- a/.github/workflows/macosx_cpn.yml
+++ b/.github/workflows/macosx_cpn.yml
@@ -24,6 +24,7 @@ on:
       source_run_id:
         description: 'Optional: prior workflow run ID to reuse build artifacts and run universal job only'
         required: false
+        default: ''
         type: string
 
 env:
@@ -49,7 +50,8 @@ jobs:
       ) &&
       (
         github.event_name != 'workflow_dispatch' ||
-        github.event.inputs.source_run_id == ''
+        github.event.inputs.source_run_id == '' ||
+        github.event.inputs.source_run_id == null
       )
     steps:
       - name: Select XCode version
@@ -134,59 +136,73 @@ jobs:
     needs: build
     runs-on: macos-15
     if: |
+      always() &&
       (
         github.event_name != 'pull_request' ||
         !contains(github.event.pull_request.labels.*.name, 'ci: skip-cpn-macos')
       ) &&
       (
         needs.build.result == 'success' ||
-        (github.event_name == 'workflow_dispatch' && github.event.inputs.source_run_id != '')
+        (
+          github.event_name == 'workflow_dispatch' &&
+          github.event.inputs.source_run_id != '' &&
+          github.event.inputs.source_run_id != null
+        )
       )
     steps:
       - name: Compose artifact ref
         shell: bash
         run: |
           artifact_ref=$(printf '%s' "${GITHUB_REF_NAME}" | sed 's#/#-#g')
+          source_run_id_raw='${{ github.event.inputs.source_run_id }}'
+          source_run_id="${source_run_id_raw##*/}"
+          source_run_id="${source_run_id%%\?*}"
+
+          if [ -n "${source_run_id_raw}" ] && ! [[ "${source_run_id}" =~ ^[0-9]+$ ]]; then
+            echo "::error::source_run_id must be a numeric run id or Actions run URL; got: ${source_run_id_raw}"
+            exit 1
+          fi
+
           echo "artifact_ref=${artifact_ref}" >> "$GITHUB_ENV"
-          echo "source_run_id=${{ github.event.inputs.source_run_id }}" >> "$GITHUB_ENV"
-          if [ -n "${{ github.event.inputs.source_run_id }}" ]; then
-            echo "Universal build mode: reuse artifacts from run_id=${{ github.event.inputs.source_run_id }}"
+          echo "source_run_id=${source_run_id}" >> "$GITHUB_ENV"
+          if [ -n "${source_run_id}" ]; then
+            echo "Universal build mode: reuse artifacts from run_id=${source_run_id}"
           else
             echo "Universal build mode: use artifacts from current workflow run"
           fi
 
       - name: Download x86_64 artifact (current run)
-        if: github.event_name != 'workflow_dispatch' || github.event.inputs.source_run_id == ''
+        if: github.event_name != 'workflow_dispatch' || github.event.inputs.source_run_id == '' || github.event.inputs.source_run_id == null
         uses: actions/download-artifact@v4
         with:
           name: "edgetx-cpn-osx-x86_64-${{ env.artifact_ref }}"
           path: output-x86_64
 
       - name: Download x86_64 artifact (from source run)
-        if: github.event_name == 'workflow_dispatch' && github.event.inputs.source_run_id != ''
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.source_run_id != '' && github.event.inputs.source_run_id != null
         uses: actions/download-artifact@v4
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.repository }}
-          run-id: ${{ github.event.inputs.source_run_id }}
+          run-id: ${{ env.source_run_id }}
           pattern: "edgetx-cpn-osx-x86_64-*"
           merge-multiple: true
           path: output-x86_64
 
       - name: Download arm64 artifact (current run)
-        if: github.event_name != 'workflow_dispatch' || github.event.inputs.source_run_id == ''
+        if: github.event_name != 'workflow_dispatch' || github.event.inputs.source_run_id == '' || github.event.inputs.source_run_id == null
         uses: actions/download-artifact@v4
         with:
           name: "edgetx-cpn-osx-arm64-${{ env.artifact_ref }}"
           path: output-arm64
 
       - name: Download arm64 artifact (from source run)
-        if: github.event_name == 'workflow_dispatch' && github.event.inputs.source_run_id != ''
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.source_run_id != '' && github.event.inputs.source_run_id != null
         uses: actions/download-artifact@v4
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.repository }}
-          run-id: ${{ github.event.inputs.source_run_id }}
+          run-id: ${{ env.source_run_id }}
           pattern: "edgetx-cpn-osx-arm64-*"
           merge-multiple: true
           path: output-arm64

--- a/.github/workflows/macosx_cpn.yml
+++ b/.github/workflows/macosx_cpn.yml
@@ -263,13 +263,13 @@ jobs:
             local hdiutil_rc=1
 
             echo "Attaching ${label} DMG at ${mount_point}"
-            if hdiutil attach -nobrowse -readonly -acceptlicense -mountpoint "${mount_point}" "${dmg_path}"; then
+            if hdiutil attach -nobrowse -readonly -noautoopen -mountpoint "${mount_point}" "${dmg_path}"; then
               return 0
             fi
 
             echo "Initial attach failed for ${label}; retrying with piped license acceptance"
             set +o pipefail
-            yes | hdiutil attach -nobrowse -readonly -acceptlicense -mountpoint "${mount_point}" "${dmg_path}"
+            yes | hdiutil attach -nobrowse -readonly -noautoopen -mountpoint "${mount_point}" "${dmg_path}"
             hdiutil_rc=${PIPESTATUS[1]:-1}
             set -o pipefail
 

--- a/.github/workflows/macosx_cpn.yml
+++ b/.github/workflows/macosx_cpn.yml
@@ -435,8 +435,29 @@ jobs:
             exit 1
           fi
 
+          attach_dmg_ci() {
+            local dmg_path="$1"
+            local mount_point="$2"
+            local rc=1
+
+            if hdiutil attach -nobrowse -readonly -noautoopen -mountpoint "${mount_point}" "${dmg_path}"; then
+              return 0
+            fi
+
+            echo "Attach retry with non-interactive license acceptance"
+            set +o pipefail
+            yes | hdiutil attach -nobrowse -readonly -noautoopen -mountpoint "${mount_point}" "${dmg_path}"
+            rc=${PIPESTATUS[1]:-1}
+            set -o pipefail
+
+            if [ "${rc}" -ne 0 ]; then
+              echo "::error::Failed to attach DMG: ${dmg_path}"
+              return "${rc}"
+            fi
+          }
+
           echo "Verifying app signature inside packaged DMG"
-          hdiutil attach -nobrowse -readonly -noautoopen -mountpoint "${VERIFY_MOUNT}" "${DMG_FILE}"
+          attach_dmg_ci "${DMG_FILE}" "${VERIFY_MOUNT}"
           DMG_APP_PATH=$(find "${VERIFY_MOUNT}" -maxdepth 1 -name '*.app' -type d -print -quit)
           if [ -z "${DMG_APP_PATH}" ]; then
             echo "::error::No .app found in packaged DMG"

--- a/.github/workflows/macosx_cpn.yml
+++ b/.github/workflows/macosx_cpn.yml
@@ -394,8 +394,11 @@ jobs:
           fi
 
           CPACK_PROJECT_DIR="/tmp/universal-dmg-cpack"
+          CPACK_OUTPUT_DIR="/tmp/universal-dmg-output"
           rm -rf "${CPACK_PROJECT_DIR}"
+          rm -rf "${CPACK_OUTPUT_DIR}"
           mkdir -p "${CPACK_PROJECT_DIR}"
+          mkdir -p "${CPACK_OUTPUT_DIR}"
 
           APP_ESCAPED="${UNIVERSAL_APP//\"/\\\"}"
           LICENSE_FILE="${GITHUB_WORKSPACE}/LICENSE"
@@ -415,11 +418,22 @@ jobs:
           EOF
 
           cmake -S "${CPACK_PROJECT_DIR}" -B "${CPACK_PROJECT_DIR}/build"
-          cpack --config "${CPACK_PROJECT_DIR}/build/CPackConfig.cmake" -B output-universal
+          cpack --config "${CPACK_PROJECT_DIR}/build/CPackConfig.cmake" -B "${CPACK_OUTPUT_DIR}"
+
+          DMG_FILE=$(find "${CPACK_OUTPUT_DIR}" -maxdepth 2 -name "${{ env.universal_dmg_name }}.dmg" -type f -print -quit)
+          if [ -z "${DMG_FILE}" ]; then
+            echo "::error::Universal DMG not found after cpack"
+            find "${CPACK_OUTPUT_DIR}" -maxdepth 4 -print || true
+            exit 1
+          fi
+
+          cp "${DMG_FILE}" output-universal/
 
       - name: Archive universal artifact
         uses: actions/upload-artifact@v4
         with:
           name: "edgetx-cpn-osx-universal-${{ env.artifact_ref }}"
-          path: output-universal
+          path: output-universal/*.dmg
+          compression-level: 0
+          if-no-files-found: error
           retention-days: 15

--- a/.github/workflows/macosx_cpn.yml
+++ b/.github/workflows/macosx_cpn.yml
@@ -431,10 +431,15 @@ jobs:
 
           RW_DMG="/tmp/edgetx-universal-template-rw.dmg"
           TEMPLATE_MOUNT="/tmp/dmg-template-universal"
+          TEMPLATE_REZ_XML="/tmp/edgetx-template-rez.xml"
+          UNIVERSAL_REZ_XML="/tmp/edgetx-universal-rez.xml"
+          MERGED_REZ_XML="/tmp/edgetx-universal-rez-merged.xml"
+          UNIVERSAL_DMG="output-universal/${{ env.universal_dmg_name }}"
 
           cleanup_package() {
             hdiutil detach "${TEMPLATE_MOUNT}" -quiet 2>/dev/null || true
             rm -f "${RW_DMG}"
+            rm -f "${TEMPLATE_REZ_XML}" "${UNIVERSAL_REZ_XML}" "${MERGED_REZ_XML}"
           }
           trap cleanup_package EXIT
 
@@ -474,7 +479,15 @@ jobs:
 
           hdiutil detach "${TEMPLATE_MOUNT}" -quiet
 
-          hdiutil convert "${RW_DMG}" -format UDZO -o "output-universal/${{ env.universal_dmg_name }}"
+          hdiutil convert "${RW_DMG}" -format UDZO -o "${UNIVERSAL_DMG}"
+
+          # Preserve template DMG resources (including SLA) while keeping universal blkx map intact
+          hdiutil udifderez -xml "${TEMPLATE_DMG}" > "${TEMPLATE_REZ_XML}"
+          hdiutil udifderez -xml "${UNIVERSAL_DMG}" > "${UNIVERSAL_REZ_XML}"
+
+          python3 -c 'import plistlib; t=plistlib.load(open("/tmp/edgetx-template-rez.xml","rb")); u=plistlib.load(open("/tmp/edgetx-universal-rez.xml","rb")); tr=t.get("resource-fork",{}); ur=u.get("resource-fork",{}); [ur.__setitem__(k,v) for k,v in tr.items() if k!="blkx"]; u["resource-fork"]=ur; plistlib.dump(u, open("/tmp/edgetx-universal-rez-merged.xml","wb"))'
+
+          hdiutil udifrez "${UNIVERSAL_DMG}" -xml "${MERGED_REZ_XML}" -replaceall
 
       - name: Archive universal artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/macosx_cpn.yml
+++ b/.github/workflows/macosx_cpn.yml
@@ -94,6 +94,7 @@ jobs:
         shell: bash
         env:
           CMAKE_BUILD_PARALLEL_LEVEL: 3
+          MACOS_APP_ONLY: 1
         run: |
           mkdir output && mkdir logs && \
           tools/build-companion.sh "$(pwd)" "$(pwd)/output/" 2>&1 | tee logs/build-main.log
@@ -150,6 +151,9 @@ jobs:
         )
       )
     steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
       - name: Compose artifact ref
         shell: bash
         run: |
@@ -221,86 +225,49 @@ jobs:
             find output-x86_64 -maxdepth 4 -print 2>/dev/null || true
             echo "--- output-arm64 files ---"
             find output-arm64 -maxdepth 4 -print 2>/dev/null || true
-            echo "--- /tmp/dmg-x86_64 contents ---"
-            ls -la /tmp/dmg-x86_64 2>/dev/null || true
-            echo "--- /tmp/dmg-arm64 contents ---"
-            ls -la /tmp/dmg-arm64 2>/dev/null || true
+            echo "--- /tmp/app-x86 contents ---"
+            find /tmp/app-x86 -maxdepth 4 -print 2>/dev/null || true
+            echo "--- /tmp/app-arm contents ---"
+            find /tmp/app-arm -maxdepth 4 -print 2>/dev/null || true
             echo "--- /tmp/app-universal contents ---"
             find /tmp/app-universal -maxdepth 4 -print 2>/dev/null || true
             return "${exit_code}"
           }
           trap on_error ERR
 
-          mkdir -p /tmp/app-universal /tmp/dmg-x86_64 /tmp/dmg-arm64 output-universal
-
-          cleanup() {
-            hdiutil detach /tmp/dmg-x86_64 -quiet 2>/dev/null || true
-            hdiutil detach /tmp/dmg-arm64 -quiet 2>/dev/null || true
-          }
-          trap cleanup EXIT
+          mkdir -p /tmp/app-universal /tmp/app-x86 /tmp/app-arm output-universal
 
           echo "Discovering input artifacts..."
           echo "output-x86_64 layout:" && find output-x86_64 -maxdepth 3 -print || true
           echo "output-arm64 layout:" && find output-arm64 -maxdepth 3 -print || true
 
-          X86_DMG=$(find output-x86_64 -name 'edgetx-companion-*.dmg' -print -quit)
-          ARM_DMG=$(find output-arm64 -name 'edgetx-companion-*.dmg' -print -quit)
+          X86_APP_ARCHIVE=$(find output-x86_64 -name '*.app.tar.gz' -print -quit)
+          ARM_APP_ARCHIVE=$(find output-arm64 -name '*.app.tar.gz' -print -quit)
 
-          if [ -z "${X86_DMG}" ] || [ -z "${ARM_DMG}" ]; then
-            echo "Could not find input DMGs in downloaded artifacts"
+          if [ -z "${X86_APP_ARCHIVE}" ] || [ -z "${ARM_APP_ARCHIVE}" ]; then
+            echo "Could not find input app archives in downloaded artifacts"
             find output-x86_64 output-arm64 -maxdepth 3 -type f || true
             exit 1
           fi
 
-          echo "x86_64 DMG: ${X86_DMG}"
-          echo "arm64 DMG: ${ARM_DMG}"
+          echo "x86_64 app archive: ${X86_APP_ARCHIVE}"
+          echo "arm64 app archive: ${ARM_APP_ARCHIVE}"
 
-          # Mount both DMGs
-          attach_dmg() {
-            local dmg_path="$1"
-            local mount_point="$2"
-            local label="$3"
-            local hdiutil_rc=1
+          tar -xzf "${X86_APP_ARCHIVE}" -C /tmp/app-x86
+          tar -xzf "${ARM_APP_ARCHIVE}" -C /tmp/app-arm
 
-            echo "Attaching ${label} DMG at ${mount_point}"
-            if hdiutil attach -nobrowse -readonly -noautoopen -mountpoint "${mount_point}" "${dmg_path}"; then
-              return 0
-            fi
-
-            echo "Initial attach failed for ${label}; retrying with piped license acceptance"
-            set +o pipefail
-            yes | hdiutil attach -nobrowse -readonly -noautoopen -mountpoint "${mount_point}" "${dmg_path}"
-            hdiutil_rc=${PIPESTATUS[1]:-1}
-            set -o pipefail
-
-            if [ "${hdiutil_rc}" -eq 0 ]; then
-              return 0
-            fi
-
-            echo "::error::Failed to attach ${label} DMG: ${dmg_path}"
-            echo "${label} DMG imageinfo:"
-            hdiutil imageinfo "${dmg_path}" || true
-            exit 1
-          }
-
-          attach_dmg "${X86_DMG}" /tmp/dmg-x86_64 x86_64
-          attach_dmg "${ARM_DMG}" /tmp/dmg-arm64 arm64
-
-          echo "Mounted x86_64 DMG:" && ls -la /tmp/dmg-x86_64
-          echo "Mounted arm64 DMG:" && ls -la /tmp/dmg-arm64
-
-          # Get app name from mounted volume
-          APP_PATH_X86=$(find /tmp/dmg-x86_64 -maxdepth 1 -name '*.app' -type d -print -quit)
+          APP_PATH_X86=$(find /tmp/app-x86 -maxdepth 2 -name '*.app' -type d -print -quit)
           if [ -z "${APP_PATH_X86}" ]; then
-            echo "No .app found inside x86_64 DMG"
+            echo "No .app found inside x86_64 archive"
             exit 1
           fi
+
           APP_NAME=$(basename "${APP_PATH_X86}")
-          APP_PATH_ARM="/tmp/dmg-arm64/${APP_NAME}"
+          APP_PATH_ARM="/tmp/app-arm/${APP_NAME}"
           if [ ! -d "${APP_PATH_ARM}" ]; then
-            echo "Matching app not found in arm64 DMG: ${APP_PATH_ARM}"
-            echo "Available arm64 apps:"
-            find /tmp/dmg-arm64 -maxdepth 1 -name '*.app' -type d -print || true
+            echo "Matching app not found in arm64 archive: ${APP_PATH_ARM}"
+            echo "Available arm64 apps in /tmp/app-arm:"
+            find /tmp/app-arm -maxdepth 2 -name '*.app' -type d -print || true
             exit 1
           fi
 
@@ -385,8 +352,11 @@ jobs:
           fi
 
           # Persist names for later steps
-          DMG_NAME=$(basename "${X86_DMG}")
-          DMG_NAME="${DMG_NAME%.dmg}-universal.dmg"
+          VERSION_FAMILY=$(printf '%s' "${APP_NAME}" | sed -E 's/^EdgeTX Companion ([0-9]+\.[0-9]+(\.[0-9]+)?).*\.app$/\1/')
+          if [ -z "${VERSION_FAMILY}" ] || [ "${VERSION_FAMILY}" = "${APP_NAME}" ]; then
+            VERSION_FAMILY="unknown"
+          fi
+          DMG_NAME="edgetx-companion-${VERSION_FAMILY}-universal"
           echo "app_name=${APP_NAME}" >> "$GITHUB_ENV"
           echo "universal_dmg_name=${DMG_NAME}" >> "$GITHUB_ENV"
 
@@ -417,77 +387,35 @@ jobs:
 
           mkdir -p output-universal
 
-          TEMPLATE_DMG=$(find output-x86_64 -name 'edgetx-companion-*.dmg' -print -quit)
-          if [ -z "${TEMPLATE_DMG}" ]; then
-            echo "::error::Unable to locate x86_64 template DMG for packaging"
-            exit 1
-          fi
-
           UNIVERSAL_APP="/tmp/app-universal/${{ env.app_name }}"
           if [ ! -d "${UNIVERSAL_APP}" ]; then
             echo "::error::Universal app not found: ${UNIVERSAL_APP}"
             exit 1
           fi
 
-          RW_DMG="/tmp/edgetx-universal-template-rw.dmg"
-          TEMPLATE_MOUNT="/tmp/dmg-template-universal"
-          TEMPLATE_REZ_XML="/tmp/edgetx-template-rez.xml"
-          UNIVERSAL_REZ_XML="/tmp/edgetx-universal-rez.xml"
-          MERGED_REZ_XML="/tmp/edgetx-universal-rez-merged.xml"
-          UNIVERSAL_DMG="output-universal/${{ env.universal_dmg_name }}"
+          CPACK_PROJECT_DIR="/tmp/universal-dmg-cpack"
+          rm -rf "${CPACK_PROJECT_DIR}"
+          mkdir -p "${CPACK_PROJECT_DIR}"
 
-          cleanup_package() {
-            hdiutil detach "${TEMPLATE_MOUNT}" -quiet 2>/dev/null || true
-            rm -f "${RW_DMG}"
-            rm -f "${TEMPLATE_REZ_XML}" "${UNIVERSAL_REZ_XML}" "${MERGED_REZ_XML}"
-          }
-          trap cleanup_package EXIT
+          APP_ESCAPED="${UNIVERSAL_APP//\"/\\\"}"
+          LICENSE_FILE="${GITHUB_WORKSPACE}/LICENSE"
+          DS_STORE_FILE="${GITHUB_WORKSPACE}/companion/targets/mac/DS_Store"
 
-          rm -f "${RW_DMG}"
-          hdiutil convert "${TEMPLATE_DMG}" -format UDRW -o "${RW_DMG}"
+          cat > "${CPACK_PROJECT_DIR}/CMakeLists.txt" <<EOF
+          cmake_minimum_required(VERSION 3.21)
+          project(EdgeTXUniversalDMG)
+          set(CPACK_GENERATOR "DragNDrop")
+          set(CPACK_BINARY_DRAGNDROP ON)
+          set(CPACK_DMG_VOLUME_NAME "EdgeTX Companion")
+          set(CPACK_PACKAGE_FILE_NAME "${{ env.universal_dmg_name }}")
+          set(CPACK_RESOURCE_FILE_LICENSE "${LICENSE_FILE}")
+          set(CPACK_DMG_DS_STORE "${DS_STORE_FILE}")
+          install(DIRECTORY "${APP_ESCAPED}" DESTINATION "." COMPONENT Runtime)
+          include(CPack)
+          EOF
 
-          universal_kb=$(du -sk "${UNIVERSAL_APP}" | awk '{print $1}')
-          required_mb=$(( (universal_kb / 1024) + 2048 ))
-          current_bytes=$(hdiutil imageinfo "${RW_DMG}" | awk -F': *' '/Total Bytes/{print $2}' | awk '{print $1}' | tr -d ',')
-          current_mb=0
-          if [[ "${current_bytes}" =~ ^[0-9]+$ ]]; then
-            current_mb=$(( (current_bytes + 1048575) / 1048576 ))
-          fi
-
-          if [ "${required_mb}" -gt "${current_mb}" ]; then
-            echo "Resizing RW DMG from ${current_mb}MB to ${required_mb}MB for universal app copy"
-            hdiutil resize -size "${required_mb}m" "${RW_DMG}"
-          else
-            echo "RW DMG size ${current_mb}MB is sufficient"
-          fi
-
-          mkdir -p "${TEMPLATE_MOUNT}"
-          hdiutil attach -nobrowse -readwrite -mountpoint "${TEMPLATE_MOUNT}" "${RW_DMG}"
-
-          TEMPLATE_APP_PATH=$(find "${TEMPLATE_MOUNT}" -maxdepth 1 -name '*.app' -type d -print -quit)
-          if [ -z "${TEMPLATE_APP_PATH}" ]; then
-            echo "::error::Template DMG does not contain an .app at root"
-            exit 1
-          fi
-
-          rm -rf "${TEMPLATE_APP_PATH}"
-          cp -R "${UNIVERSAL_APP}" "${TEMPLATE_MOUNT}/"
-
-          if [ ! -e "${TEMPLATE_MOUNT}/Applications" ]; then
-            ln -s /Applications "${TEMPLATE_MOUNT}/Applications"
-          fi
-
-          hdiutil detach "${TEMPLATE_MOUNT}" -quiet
-
-          hdiutil convert "${RW_DMG}" -format UDZO -o "${UNIVERSAL_DMG}"
-
-          # Preserve template DMG resources (including SLA) while keeping universal blkx map intact
-          hdiutil udifderez -xml "${TEMPLATE_DMG}" > "${TEMPLATE_REZ_XML}"
-          hdiutil udifderez -xml "${UNIVERSAL_DMG}" > "${UNIVERSAL_REZ_XML}"
-
-          python3 -c 'import plistlib; t=plistlib.load(open("/tmp/edgetx-template-rez.xml","rb")); u=plistlib.load(open("/tmp/edgetx-universal-rez.xml","rb")); tr=t.get("resource-fork",{}); ur=u.get("resource-fork",{}); [ur.__setitem__(k,v) for k,v in tr.items() if k!="blkx"]; u["resource-fork"]=ur; plistlib.dump(u, open("/tmp/edgetx-universal-rez-merged.xml","wb"))'
-
-          hdiutil udifrez "${UNIVERSAL_DMG}" -xml "${MERGED_REZ_XML}" -replaceall
+          cmake -S "${CPACK_PROJECT_DIR}" -B "${CPACK_PROJECT_DIR}/build"
+          cpack --config "${CPACK_PROJECT_DIR}/build/CPackConfig.cmake" -B output-universal
 
       - name: Archive universal artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/macosx_cpn.yml
+++ b/.github/workflows/macosx_cpn.yml
@@ -309,9 +309,11 @@ jobs:
 
           # Lipo all Mach-O files
           merged_count=0
+          reused_universal_count=0
           skipped_count=0
           missing_count=0
-          find "${APP_PATH_X86}" -type f -print0 | while IFS= read -r -d '' f_x86; do
+          macho_count=0
+          while IFS= read -r -d '' f_x86; do
             rel="${f_x86#${APP_PATH_X86}/}"
             f_arm="${APP_PATH_ARM}/${rel}"
             f_out="/tmp/app-universal/${APP_NAME}/${rel}"
@@ -333,21 +335,52 @@ jobs:
               continue
             fi
 
-            if ! lipo -create "${f_x86}" "${f_arm}" -output "${f_out}"; then
+            macho_count=$((macho_count + 1))
+
+            arch_x86=$(lipo -archs "${f_x86}" 2>/dev/null || true)
+            arch_arm=$(lipo -archs "${f_arm}" 2>/dev/null || true)
+
+            src_x86=""
+            src_arm=""
+            if echo " ${arch_x86} " | grep -q ' x86_64 '; then src_x86="${f_x86}"; fi
+            if echo " ${arch_x86} " | grep -q ' arm64 '; then src_arm="${f_x86}"; fi
+            if [ -z "${src_x86}" ] && echo " ${arch_arm} " | grep -q ' x86_64 '; then src_x86="${f_arm}"; fi
+            if [ -z "${src_arm}" ] && echo " ${arch_arm} " | grep -q ' arm64 '; then src_arm="${f_arm}"; fi
+
+            if [ "${src_x86}" = "${f_x86}" ] && [ "${src_arm}" = "${f_x86}" ]; then
+              reused_universal_count=$((reused_universal_count + 1))
+              continue
+            fi
+
+            if [ -z "${src_x86}" ] || [ -z "${src_arm}" ]; then
+              echo "Missing required architectures for: ${rel}"
+              echo "x86_64 arches: ${arch_x86}"
+              echo "arm64 arches:  ${arch_arm}"
+              missing_count=$((missing_count + 1))
+              continue
+            fi
+
+            if ! lipo -create -arch x86_64 "${src_x86}" -arch arm64 "${src_arm}" -output "${f_out}"; then
               echo "::error::lipo failed for ${rel}"
               echo "x86_64: $(file "${f_x86}")"
               echo "arm64:  $(file "${f_arm}")"
+              echo "x86_64 arches: ${arch_x86}"
+              echo "arm64 arches:  ${arch_arm}"
               lipo -info "${f_x86}" || true
               lipo -info "${f_arm}" || true
               exit 1
             fi
 
             merged_count=$((merged_count + 1))
-          done
+          done < <(find "${APP_PATH_X86}" -type f -print0)
 
-          echo "Lipo merge summary: merged=${merged_count}, skipped_non_macho=${skipped_count}, missing_counterparts=${missing_count}"
-          if [ "${merged_count}" -eq 0 ]; then
-            echo "::error::No Mach-O binaries were merged"
+          echo "Lipo merge summary: macho=${macho_count}, merged=${merged_count}, reused_universal=${reused_universal_count}, skipped_non_macho=${skipped_count}, missing_counterparts=${missing_count}"
+          if [ "${macho_count}" -eq 0 ]; then
+            echo "::error::No Mach-O binaries found to process"
+            exit 1
+          fi
+          if [ $((merged_count + reused_universal_count)) -eq 0 ]; then
+            echo "::error::No universal binaries were produced"
             exit 1
           fi
 

--- a/.github/workflows/macosx_cpn.yml
+++ b/.github/workflows/macosx_cpn.yml
@@ -6,7 +6,7 @@ on:
       - 'main'
       - '[0-9]+.[0-9]+'
     tags:
-      - v*  
+      - v*
     paths: &trigger-paths
       - '.github/workflows/macosx_cpn.yml'
       - 'companion/**'
@@ -97,7 +97,7 @@ jobs:
 
       - name: Compose release filename
         if: always()
-        run: echo "artifact_name=edgetx-cpn-osx-${{ matrix.arch }}-${GITHUB_REF##*/}" >> $GITHUB_ENV
+        run: echo "artifact_name=edgetx-cpn-osx-${{ matrix.arch }}-${{ github.ref_name }}" >> $GITHUB_ENV
 
       - name: Archive production artifacts
         if: success()
@@ -123,18 +123,18 @@ jobs:
       !contains(github.event.pull_request.labels.*.name, 'ci: skip-cpn-macos')
     steps:
       - name: Compose release filename base
-        run: echo "artifact_base=edgetx-cpn-osx-${GITHUB_REF##*/}" >> $GITHUB_ENV
+        run: echo "artifact_base=edgetx-cpn-osx-${{ github.ref_name }}" >> $GITHUB_ENV
 
       - name: Download x86_64 artifact
         uses: actions/download-artifact@v4
         with:
-          name: "edgetx-cpn-osx-x86_64-${GITHUB_REF##*/}"
+          name: "edgetx-cpn-osx-x86_64-${{ github.ref_name }}"
           path: output-x86_64
 
       - name: Download arm64 artifact
         uses: actions/download-artifact@v4
         with:
-          name: "edgetx-cpn-osx-arm64-${GITHUB_REF##*/}"
+          name: "edgetx-cpn-osx-arm64-${{ github.ref_name }}"
           path: output-arm64
 
       - name: Create universal binaries with lipo
@@ -193,6 +193,6 @@ jobs:
       - name: Archive universal artifact
         uses: actions/upload-artifact@v4
         with:
-          name: "edgetx-cpn-osx-universal-${GITHUB_REF##*/}"
+          name: "edgetx-cpn-osx-universal-${{ github.ref_name }}"
           path: output-universal
           retention-days: 15

--- a/.github/workflows/macosx_cpn.yml
+++ b/.github/workflows/macosx_cpn.yml
@@ -1,24 +1,30 @@
 name: MacOSX Companion
 
 on:
-  push:
-    branches:
-      - 'main'
-      - '[0-9]+.[0-9]+'
-    tags:
-      - v*
-    paths: &trigger-paths
-      - '.github/workflows/macosx_cpn.yml'
-      - 'companion/**'
-      - 'tools/build-companion.sh'
+  # auto triggers disabled while universal job is being debugged.
+  # push:
+  #   branches:
+  #     - 'main'
+  #     - '[0-9]+.[0-9]+'
+  #   tags:
+  #     - v*
+  #   paths: &trigger-paths
+  #     - '.github/workflows/macosx_cpn.yml'
+  #     - 'companion/**'
+  #     - 'tools/build-companion.sh'
 
-  pull_request:
-    branches:
-      - 'main'
-      - '[0-9]+.[0-9]+'
-    paths: *trigger-paths
+  # pull_request:
+  #   branches:
+  #     - 'main'
+  #     - '[0-9]+.[0-9]+'
+  #   paths: *trigger-paths
 
   workflow_dispatch:
+    inputs:
+      source_run_id:
+        description: 'Optional: prior workflow run ID to reuse build artifacts and run universal job only'
+        required: false
+        type: string
 
 env:
   BUILD_TYPE: Release
@@ -37,8 +43,14 @@ jobs:
             cache-suffix: arm64
     runs-on: ${{ matrix.runner }}
     if: |
-      github.event_name != 'pull_request' ||
-      !contains(github.event.pull_request.labels.*.name, 'ci: skip-cpn-macos')
+      (
+        github.event_name != 'pull_request' ||
+        !contains(github.event.pull_request.labels.*.name, 'ci: skip-cpn-macos')
+      ) &&
+      (
+        github.event_name != 'workflow_dispatch' ||
+        github.event.inputs.source_run_id == ''
+      )
     steps:
       - name: Select XCode version
         uses: maxim-lobanov/setup-xcode@v1
@@ -108,7 +120,7 @@ jobs:
         with:
           name: "${{ env.artifact_name }}"
           path: ${{github.workspace}}/output
-          retention-days: 1  # Short retention, only needed for the universal job
+          retention-days: 3  # Short retention, only needed for the universal job
 
       - name: Archive build logs
         if: always()
@@ -122,31 +134,86 @@ jobs:
     needs: build
     runs-on: macos-15
     if: |
-      github.event_name != 'pull_request' ||
-      !contains(github.event.pull_request.labels.*.name, 'ci: skip-cpn-macos')
+      (
+        github.event_name != 'pull_request' ||
+        !contains(github.event.pull_request.labels.*.name, 'ci: skip-cpn-macos')
+      ) &&
+      (
+        needs.build.result == 'success' ||
+        (github.event_name == 'workflow_dispatch' && github.event.inputs.source_run_id != '')
+      )
     steps:
       - name: Compose artifact ref
         shell: bash
         run: |
           artifact_ref=$(printf '%s' "${GITHUB_REF_NAME}" | sed 's#/#-#g')
           echo "artifact_ref=${artifact_ref}" >> "$GITHUB_ENV"
+          echo "source_run_id=${{ github.event.inputs.source_run_id }}" >> "$GITHUB_ENV"
+          if [ -n "${{ github.event.inputs.source_run_id }}" ]; then
+            echo "Universal build mode: reuse artifacts from run_id=${{ github.event.inputs.source_run_id }}"
+          else
+            echo "Universal build mode: use artifacts from current workflow run"
+          fi
 
-      - name: Download x86_64 artifact
+      - name: Download x86_64 artifact (current run)
+        if: github.event_name != 'workflow_dispatch' || github.event.inputs.source_run_id == ''
         uses: actions/download-artifact@v4
         with:
           name: "edgetx-cpn-osx-x86_64-${{ env.artifact_ref }}"
           path: output-x86_64
 
-      - name: Download arm64 artifact
+      - name: Download x86_64 artifact (from source run)
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.source_run_id != ''
+        uses: actions/download-artifact@v4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.repository }}
+          run-id: ${{ github.event.inputs.source_run_id }}
+          pattern: "edgetx-cpn-osx-x86_64-*"
+          merge-multiple: true
+          path: output-x86_64
+
+      - name: Download arm64 artifact (current run)
+        if: github.event_name != 'workflow_dispatch' || github.event.inputs.source_run_id == ''
         uses: actions/download-artifact@v4
         with:
           name: "edgetx-cpn-osx-arm64-${{ env.artifact_ref }}"
+          path: output-arm64
+
+      - name: Download arm64 artifact (from source run)
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.source_run_id != ''
+        uses: actions/download-artifact@v4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.repository }}
+          run-id: ${{ github.event.inputs.source_run_id }}
+          pattern: "edgetx-cpn-osx-arm64-*"
+          merge-multiple: true
           path: output-arm64
 
       - name: Create universal binaries with lipo
         shell: bash
         run: |
           set -euo pipefail
+
+          on_error() {
+            local exit_code=$?
+            local line_no=${BASH_LINENO[0]:-unknown}
+            local cmd=${BASH_COMMAND:-unknown}
+            echo "::error::Create universal binaries failed at line ${line_no}: ${cmd} (exit ${exit_code})"
+            echo "--- output-x86_64 files ---"
+            find output-x86_64 -maxdepth 4 -print 2>/dev/null || true
+            echo "--- output-arm64 files ---"
+            find output-arm64 -maxdepth 4 -print 2>/dev/null || true
+            echo "--- /tmp/dmg-x86_64 contents ---"
+            ls -la /tmp/dmg-x86_64 2>/dev/null || true
+            echo "--- /tmp/dmg-arm64 contents ---"
+            ls -la /tmp/dmg-arm64 2>/dev/null || true
+            echo "--- /tmp/app-universal contents ---"
+            find /tmp/app-universal -maxdepth 4 -print 2>/dev/null || true
+            return "${exit_code}"
+          }
+          trap on_error ERR
 
           mkdir -p /tmp/app-universal /tmp/dmg-x86_64 /tmp/dmg-arm64 output-universal
 
@@ -155,6 +222,10 @@ jobs:
             hdiutil detach /tmp/dmg-arm64 -quiet 2>/dev/null || true
           }
           trap cleanup EXIT
+
+          echo "Discovering input artifacts..."
+          echo "output-x86_64 layout:" && find output-x86_64 -maxdepth 3 -print || true
+          echo "output-arm64 layout:" && find output-arm64 -maxdepth 3 -print || true
 
           X86_DMG=$(find output-x86_64 -name 'edgetx-companion-*.dmg' -print -quit)
           ARM_DMG=$(find output-arm64 -name 'edgetx-companion-*.dmg' -print -quit)
@@ -165,9 +236,15 @@ jobs:
             exit 1
           fi
 
+          echo "x86_64 DMG: ${X86_DMG}"
+          echo "arm64 DMG: ${ARM_DMG}"
+
           # Mount both DMGs
-          hdiutil attach "${X86_DMG}" -mountpoint /tmp/dmg-x86_64 -nobrowse -quiet
-          hdiutil attach "${ARM_DMG}" -mountpoint /tmp/dmg-arm64 -nobrowse -quiet
+          hdiutil attach "${X86_DMG}" -mountpoint /tmp/dmg-x86_64 -nobrowse
+          hdiutil attach "${ARM_DMG}" -mountpoint /tmp/dmg-arm64 -nobrowse
+
+          echo "Mounted x86_64 DMG:" && ls -la /tmp/dmg-x86_64
+          echo "Mounted arm64 DMG:" && ls -la /tmp/dmg-arm64
 
           # Get app name from mounted volume
           APP_PATH_X86=$(find /tmp/dmg-x86_64 -maxdepth 1 -name '*.app' -type d -print -quit)
@@ -176,20 +253,60 @@ jobs:
             exit 1
           fi
           APP_NAME=$(basename "${APP_PATH_X86}")
+          APP_PATH_ARM="/tmp/dmg-arm64/${APP_NAME}"
+          if [ ! -d "${APP_PATH_ARM}" ]; then
+            echo "Matching app not found in arm64 DMG: ${APP_PATH_ARM}"
+            echo "Available arm64 apps:"
+            find /tmp/dmg-arm64 -maxdepth 1 -name '*.app' -type d -print || true
+            exit 1
+          fi
 
           # Copy x86_64 app as base
           cp -R "${APP_PATH_X86}" /tmp/app-universal/
 
           # Lipo all Mach-O files
+          merged_count=0
+          skipped_count=0
+          missing_count=0
           find "${APP_PATH_X86}" -type f -print0 | while IFS= read -r -d '' f_x86; do
             rel="${f_x86#${APP_PATH_X86}/}"
-            f_arm="/tmp/dmg-arm64/${APP_NAME}/${rel}"
+            f_arm="${APP_PATH_ARM}/${rel}"
             f_out="/tmp/app-universal/${APP_NAME}/${rel}"
 
-            if [ -f "${f_arm}" ] && file "${f_x86}" | grep -qE 'Mach-O'; then
-              lipo -create "${f_x86}" "${f_arm}" -output "${f_out}"
+            if ! file "${f_x86}" | grep -qE 'Mach-O'; then
+              skipped_count=$((skipped_count + 1))
+              continue
             fi
+
+            if [ ! -f "${f_arm}" ]; then
+              echo "Missing arm64 counterpart for: ${rel}"
+              missing_count=$((missing_count + 1))
+              continue
+            fi
+
+            if ! file "${f_arm}" | grep -qE 'Mach-O'; then
+              echo "Non-Mach-O arm64 counterpart for: ${rel}"
+              skipped_count=$((skipped_count + 1))
+              continue
+            fi
+
+            if ! lipo -create "${f_x86}" "${f_arm}" -output "${f_out}"; then
+              echo "::error::lipo failed for ${rel}"
+              echo "x86_64: $(file "${f_x86}")"
+              echo "arm64:  $(file "${f_arm}")"
+              lipo -info "${f_x86}" || true
+              lipo -info "${f_arm}" || true
+              exit 1
+            fi
+
+            merged_count=$((merged_count + 1))
           done
+
+          echo "Lipo merge summary: merged=${merged_count}, skipped_non_macho=${skipped_count}, missing_counterparts=${missing_count}"
+          if [ "${merged_count}" -eq 0 ]; then
+            echo "::error::No Mach-O binaries were merged"
+            exit 1
+          fi
 
           # Persist names for later steps
           DMG_NAME=$(basename "${X86_DMG}")

--- a/.github/workflows/macosx_cpn.yml
+++ b/.github/workflows/macosx_cpn.yml
@@ -97,7 +97,10 @@ jobs:
 
       - name: Compose release filename
         if: always()
-        run: echo "artifact_name=edgetx-cpn-osx-${{ matrix.arch }}-${{ github.ref_name }}" >> $GITHUB_ENV
+        shell: bash
+        run: |
+          artifact_ref=$(printf '%s' "${GITHUB_REF_NAME}" | sed 's#/#-#g')
+          echo "artifact_name=edgetx-cpn-osx-${{ matrix.arch }}-${artifact_ref}" >> "$GITHUB_ENV"
 
       - name: Archive production artifacts
         if: success()
@@ -122,19 +125,22 @@ jobs:
       github.event_name != 'pull_request' ||
       !contains(github.event.pull_request.labels.*.name, 'ci: skip-cpn-macos')
     steps:
-      - name: Compose release filename base
-        run: echo "artifact_base=edgetx-cpn-osx-${{ github.ref_name }}" >> $GITHUB_ENV
+      - name: Compose artifact ref
+        shell: bash
+        run: |
+          artifact_ref=$(printf '%s' "${GITHUB_REF_NAME}" | sed 's#/#-#g')
+          echo "artifact_ref=${artifact_ref}" >> "$GITHUB_ENV"
 
       - name: Download x86_64 artifact
         uses: actions/download-artifact@v4
         with:
-          name: "edgetx-cpn-osx-x86_64-${{ github.ref_name }}"
+          name: "edgetx-cpn-osx-x86_64-${{ env.artifact_ref }}"
           path: output-x86_64
 
       - name: Download arm64 artifact
         uses: actions/download-artifact@v4
         with:
-          name: "edgetx-cpn-osx-arm64-${{ github.ref_name }}"
+          name: "edgetx-cpn-osx-arm64-${{ env.artifact_ref }}"
           path: output-arm64
 
       - name: Create universal binaries with lipo
@@ -193,6 +199,6 @@ jobs:
       - name: Archive universal artifact
         uses: actions/upload-artifact@v4
         with:
-          name: "edgetx-cpn-osx-universal-${{ github.ref_name }}"
+          name: "edgetx-cpn-osx-universal-${{ env.artifact_ref }}"
           path: output-universal
           retention-days: 15

--- a/.github/workflows/macosx_cpn.yml
+++ b/.github/workflows/macosx_cpn.yml
@@ -186,6 +186,13 @@ jobs:
             fi
           done
 
+      - name: Ad-hoc code sign universal binaries
+        shell: bash
+        run: |
+          find output-universal -name "*.app" -type d | while read app; do
+            codesign --force --deep --sign - "$app"
+          done
+
       - name: Verify universal binaries
         shell: bash
         run: |

--- a/.github/workflows/macosx_cpn.yml
+++ b/.github/workflows/macosx_cpn.yml
@@ -146,56 +146,85 @@ jobs:
       - name: Create universal binaries with lipo
         shell: bash
         run: |
-          mkdir -p /tmp/app-universal
+          set -euo pipefail
+
+          mkdir -p /tmp/app-universal /tmp/dmg-x86_64 /tmp/dmg-arm64 output-universal
+
+          cleanup() {
+            hdiutil detach /tmp/dmg-x86_64 -quiet 2>/dev/null || true
+            hdiutil detach /tmp/dmg-arm64 -quiet 2>/dev/null || true
+          }
+          trap cleanup EXIT
+
+          X86_DMG=$(find output-x86_64 -name 'edgetx-companion-*.dmg' -print -quit)
+          ARM_DMG=$(find output-arm64 -name 'edgetx-companion-*.dmg' -print -quit)
+
+          if [ -z "${X86_DMG}" ] || [ -z "${ARM_DMG}" ]; then
+            echo "Could not find input DMGs in downloaded artifacts"
+            find output-x86_64 output-arm64 -maxdepth 3 -type f || true
+            exit 1
+          fi
 
           # Mount both DMGs
-          hdiutil attach output-x86_64/edgetx-companion-*.dmg -mountpoint /tmp/dmg-x86_64 -nobrowse -quiet
-          hdiutil attach output-arm64/edgetx-companion-*.dmg -mountpoint /tmp/dmg-arm64 -nobrowse -quiet
+          hdiutil attach "${X86_DMG}" -mountpoint /tmp/dmg-x86_64 -nobrowse -quiet
+          hdiutil attach "${ARM_DMG}" -mountpoint /tmp/dmg-arm64 -nobrowse -quiet
 
           # Get app name from mounted volume
-          APP_NAME=$(ls /tmp/dmg-x86_64/ | grep "\.app$" | head -1)
+          APP_PATH_X86=$(find /tmp/dmg-x86_64 -maxdepth 1 -name '*.app' -type d -print -quit)
+          if [ -z "${APP_PATH_X86}" ]; then
+            echo "No .app found inside x86_64 DMG"
+            exit 1
+          fi
+          APP_NAME=$(basename "${APP_PATH_X86}")
 
           # Copy x86_64 app as base
-          cp -R "/tmp/dmg-x86_64/${APP_NAME}" /tmp/app-universal/
+          cp -R "${APP_PATH_X86}" /tmp/app-universal/
 
           # Lipo all Mach-O files
-          find "/tmp/dmg-x86_64/${APP_NAME}" -type f | while read f_x86; do
-            rel="${f_x86#/tmp/dmg-x86_64/${APP_NAME}/}"
+          find "${APP_PATH_X86}" -type f -print0 | while IFS= read -r -d '' f_x86; do
+            rel="${f_x86#${APP_PATH_X86}/}"
             f_arm="/tmp/dmg-arm64/${APP_NAME}/${rel}"
             f_out="/tmp/app-universal/${APP_NAME}/${rel}"
 
-            if [ -f "$f_arm" ] && file "$f_x86" | grep -qE 'Mach-O'; then
-              lipo -create "$f_x86" "$f_arm" -output "$f_out"
+            if [ -f "${f_arm}" ] && file "${f_x86}" | grep -qE 'Mach-O'; then
+              lipo -create "${f_x86}" "${f_arm}" -output "${f_out}"
             fi
           done
 
-          # Detach DMGs
-          hdiutil detach /tmp/dmg-x86_64 -quiet
-          hdiutil detach /tmp/dmg-arm64 -quiet
-
-          # Get version from DMG filename for output naming
-          DMG_NAME=$(ls output-x86_64/edgetx-companion-*.dmg | xargs basename | sed 's/\.dmg/-universal.dmg/')
-          hdiutil create -volname "${APP_NAME%.app}" \
-            -srcfolder /tmp/app-universal \
-            -ov -format UDZO \
-            "output-universal/${DMG_NAME}"
+          # Persist names for later steps
+          DMG_NAME=$(basename "${X86_DMG}")
+          DMG_NAME="${DMG_NAME%.dmg}-universal.dmg"
+          echo "app_name=${APP_NAME}" >> "$GITHUB_ENV"
+          echo "universal_dmg_name=${DMG_NAME}" >> "$GITHUB_ENV"
 
       - name: Ad-hoc code sign universal binaries
         shell: bash
         run: |
-          find output-universal -name "*.app" -type d | while read app; do
-            codesign --force --deep --sign - "$app"
+          find /tmp/app-universal -name "*.app" -type d | while read app; do
+            codesign --force --deep --sign - --timestamp=none "$app"
+            codesign --verify --deep --strict "$app"
           done
 
       - name: Verify universal binaries
         shell: bash
         run: |
-          find output-universal -type f | while read f; do
+          find "/tmp/app-universal/${{ env.app_name }}" -type f | while read f; do
             if file "$f" | grep -qE 'Mach-O'; then
               echo "=== $f ==="
               lipo -info "$f"
+              lipo -info "$f" | grep -q 'x86_64'
+              lipo -info "$f" | grep -q 'arm64'
             fi
           done
+
+      - name: Package universal DMG
+        shell: bash
+        run: |
+          mkdir -p output-universal
+          hdiutil create -volname "${{ env.app_name }}" \
+            -srcfolder /tmp/app-universal \
+            -ov -format UDZO \
+            "output-universal/${{ env.universal_dmg_name }}"
 
       - name: Archive universal artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/macosx_cpn.yml
+++ b/.github/workflows/macosx_cpn.yml
@@ -1,23 +1,22 @@
 name: MacOSX Companion
 
 on:
-  # auto triggers disabled while universal job is being debugged.
-  # push:
-  #   branches:
-  #     - 'main'
-  #     - '[0-9]+.[0-9]+'
-  #   tags:
-  #     - v*
-  #   paths: &trigger-paths
-  #     - '.github/workflows/macosx_cpn.yml'
-  #     - 'companion/**'
-  #     - 'tools/build-companion.sh'
+  push:
+    branches:
+      - 'main'
+      - '[0-9]+.[0-9]+'
+    tags:
+      - v*
+    paths: &trigger-paths
+      - '.github/workflows/macosx_cpn.yml'
+      - 'companion/**'
+      - 'tools/build-companion.sh'
 
-  # pull_request:
-  #   branches:
-  #     - 'main'
-  #     - '[0-9]+.[0-9]+'
-  #   paths: *trigger-paths
+  pull_request:
+    branches:
+      - 'main'
+      - '[0-9]+.[0-9]+'
+    paths: *trigger-paths
 
   workflow_dispatch:
     inputs:
@@ -221,25 +220,15 @@ jobs:
             local line_no=${BASH_LINENO[0]:-unknown}
             local cmd=${BASH_COMMAND:-unknown}
             echo "::error::Create universal binaries failed at line ${line_no}: ${cmd} (exit ${exit_code})"
-            echo "--- output-x86_64 files ---"
-            find output-x86_64 -maxdepth 4 -print 2>/dev/null || true
-            echo "--- output-arm64 files ---"
-            find output-arm64 -maxdepth 4 -print 2>/dev/null || true
-            echo "--- /tmp/app-x86 contents ---"
-            find /tmp/app-x86 -maxdepth 4 -print 2>/dev/null || true
-            echo "--- /tmp/app-arm contents ---"
-            find /tmp/app-arm -maxdepth 4 -print 2>/dev/null || true
-            echo "--- /tmp/app-universal contents ---"
-            find /tmp/app-universal -maxdepth 4 -print 2>/dev/null || true
+            echo "x86 archive path: ${X86_APP_ARCHIVE:-<unset>}"
+            echo "arm archive path: ${ARM_APP_ARCHIVE:-<unset>}"
+            echo "app name: ${APP_NAME:-<unset>}"
+            ls -la /tmp/app-universal 2>/dev/null || true
             return "${exit_code}"
           }
           trap on_error ERR
 
           mkdir -p /tmp/app-universal /tmp/app-x86 /tmp/app-arm output-universal
-
-          echo "Discovering input artifacts..."
-          echo "output-x86_64 layout:" && find output-x86_64 -maxdepth 3 -print || true
-          echo "output-arm64 layout:" && find output-arm64 -maxdepth 3 -print || true
 
           X86_APP_ARCHIVE=$(find output-x86_64 -name '*.app.tar.gz' -print -quit)
           ARM_APP_ARCHIVE=$(find output-arm64 -name '*.app.tar.gz' -print -quit)
@@ -366,6 +355,13 @@ jobs:
               chmod 755 "$f"
             fi
           done
+
+          MAIN_EXECUTABLE="${APP_UNIVERSAL_PATH}/Contents/MacOS/companion"
+          if [ ! -x "${MAIN_EXECUTABLE}" ]; then
+            echo "::error::Main executable is not marked executable: ${MAIN_EXECUTABLE}"
+            ls -l "${APP_UNIVERSAL_PATH}/Contents/MacOS" || true
+            exit 1
+          fi
 
           # Persist names for later steps
           VERSION_FAMILY=$(printf '%s' "${APP_NAME}" | sed -E 's/^EdgeTX Companion ([0-9]+\.[0-9]+(\.[0-9]+)?).*\.app$/\1/')

--- a/.github/workflows/macosx_cpn.yml
+++ b/.github/workflows/macosx_cpn.yml
@@ -364,11 +364,18 @@ jobs:
           fi
 
           # Persist names for later steps
-          VERSION_FAMILY=$(printf '%s' "${APP_NAME}" | sed -E 's/^EdgeTX Companion ([0-9]+\.[0-9]+(\.[0-9]+)?).*\.app$/\1/')
-          if [ -z "${VERSION_FAMILY}" ] || [ "${VERSION_FAMILY}" = "${APP_NAME}" ]; then
-            VERSION_FAMILY="unknown"
+          APP_UNIVERSAL_INFO_PLIST="${APP_UNIVERSAL_PATH}/Contents/Info.plist"
+          VERSION_FULL=""
+          if [ -f "${APP_UNIVERSAL_INFO_PLIST}" ]; then
+            VERSION_FULL=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "${APP_UNIVERSAL_INFO_PLIST}" 2>/dev/null || true)
           fi
-          DMG_NAME="edgetx-companion-${VERSION_FAMILY}-universal"
+          if [ -z "${VERSION_FULL}" ]; then
+            VERSION_FULL=$(printf '%s' "${APP_NAME}" | sed -E 's/^EdgeTX Companion ([0-9]+\.[0-9]+(\.[0-9]+)?).*\.app$/\1/')
+          fi
+          if [ -z "${VERSION_FULL}" ] || [ "${VERSION_FULL}" = "${APP_NAME}" ]; then
+            VERSION_FULL="unknown"
+          fi
+          DMG_NAME="edgetx-companion-${VERSION_FULL}-universal"
           echo "app_name=${APP_NAME}" >> "$GITHUB_ENV"
           echo "universal_dmg_name=${DMG_NAME}" >> "$GITHUB_ENV"
 

--- a/.github/workflows/macosx_cpn.yml
+++ b/.github/workflows/macosx_cpn.yml
@@ -338,6 +338,11 @@ jobs:
               exit 1
             fi
 
+            src_mode=$(stat -f '%Lp' "${f_x86}" 2>/dev/null || true)
+            if [ -n "${src_mode}" ]; then
+              chmod "${src_mode}" "${f_out}" || true
+            fi
+
             merged_count=$((merged_count + 1))
           done < <(find "${APP_PATH_X86}" -type f -print0)
 

--- a/.github/workflows/macosx_cpn.yml
+++ b/.github/workflows/macosx_cpn.yml
@@ -260,6 +260,7 @@ jobs:
             local dmg_path="$1"
             local mount_point="$2"
             local label="$3"
+            local hdiutil_rc=1
 
             echo "Attaching ${label} DMG at ${mount_point}"
             if hdiutil attach -nobrowse -readonly -acceptlicense -mountpoint "${mount_point}" "${dmg_path}"; then
@@ -267,7 +268,12 @@ jobs:
             fi
 
             echo "Initial attach failed for ${label}; retrying with piped license acceptance"
-            if yes | hdiutil attach -nobrowse -readonly -acceptlicense -mountpoint "${mount_point}" "${dmg_path}"; then
+            set +o pipefail
+            yes | hdiutil attach -nobrowse -readonly -acceptlicense -mountpoint "${mount_point}" "${dmg_path}"
+            hdiutil_rc=${PIPESTATUS[1]:-1}
+            set -o pipefail
+
+            if [ "${hdiutil_rc}" -eq 0 ]; then
               return 0
             fi
 

--- a/.github/workflows/macosx_cpn.yml
+++ b/.github/workflows/macosx_cpn.yml
@@ -21,13 +21,21 @@ on:
   workflow_dispatch:
 
 env:
-  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Release
   QT_VERSION: "6.9.3"
 
 jobs:
   build:
-    runs-on: macos-15-intel
+    strategy:
+      matrix:
+        include:
+          - runner: macos-15-intel
+            arch: x86_64
+            cache-suffix: intel
+          - runner: macos-15
+            arch: arm64
+            cache-suffix: arm64
+    runs-on: ${{ matrix.runner }}
     if: |
       github.event_name != 'pull_request' ||
       !contains(github.event.pull_request.labels.*.name, 'ci: skip-cpn-macos')
@@ -48,8 +56,6 @@ jobs:
           python-version: '3.12'
 
       - name: Create Build Environment
-        # Some projects don't allow in-source building, so create a separate build directory
-        # We'll use this as our working directory for all subsequent commands
         run: cmake -E make_directory ${{github.workspace}}/build
 
       - name: Install Qt
@@ -61,13 +67,13 @@ jobs:
           modules: 'qtmultimedia qtserialport'
           setup-python: 'false'
           cache: true
-          cache-key-prefix: 'install-qt-action-macOS'
+          cache-key-prefix: 'install-qt-action-macOS-${{ matrix.cache-suffix }}'
 
       - name: Install dependencies
         run: python3 -m pip install --upgrade pip Pillow lz4 clang jinja2
 
       - name: Install SDL2
-        run:  brew install SDL2
+        run: brew install SDL2
 
       - name: Build
         working-directory: ${{github.workspace}}
@@ -82,10 +88,7 @@ jobs:
         if: always()
         shell: bash
         run: |
-          # Create logs directory if it doesn't exist
           mkdir -p logs
-          
-          # Copy all build logs from the build directory
           if [ -d "build" ]; then
             find build -name "*.log" -type f -exec cp {} logs/ \; 2>/dev/null || true
             find build -name "CMakeOutput.log" -type f -exec cp {} logs/ \; 2>/dev/null || true
@@ -94,16 +97,15 @@ jobs:
 
       - name: Compose release filename
         if: always()
-        # https://stackoverflow.com/questions/58033366/how-to-get-current-branch-within-github-actions
-        run: echo "artifact_name=edgetx-cpn-osx-${GITHUB_REF##*/}" >> $GITHUB_ENV
+        run: echo "artifact_name=edgetx-cpn-osx-${{ matrix.arch }}-${GITHUB_REF##*/}" >> $GITHUB_ENV
 
       - name: Archive production artifacts
         if: success()
         uses: actions/upload-artifact@v4
         with:
           name: "${{ env.artifact_name }}"
-          path:  ${{github.workspace}}/output
-          retention-days: 15
+          path: ${{github.workspace}}/output
+          retention-days: 1  # Short retention, only needed for the universal job
 
       - name: Archive build logs
         if: always()
@@ -112,3 +114,85 @@ jobs:
           name: "${{ env.artifact_name }}-logs"
           path: ${{github.workspace}}/logs
           retention-days: 30
+
+  universal:
+    needs: build
+    runs-on: macos-15
+    if: |
+      github.event_name != 'pull_request' ||
+      !contains(github.event.pull_request.labels.*.name, 'ci: skip-cpn-macos')
+    steps:
+      - name: Compose release filename base
+        run: echo "artifact_base=edgetx-cpn-osx-${GITHUB_REF##*/}" >> $GITHUB_ENV
+
+      - name: Download x86_64 artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: "edgetx-cpn-osx-x86_64-${GITHUB_REF##*/}"
+          path: output-x86_64
+
+      - name: Download arm64 artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: "edgetx-cpn-osx-arm64-${GITHUB_REF##*/}"
+          path: output-arm64
+
+      - name: Create universal binaries with lipo
+        shell: bash
+        run: |
+          mkdir -p output-universal
+
+          # Find all .app bundles in the x86_64 output and process them
+          find output-x86_64 -name "*.app" -type d | while read app_x86; do
+            app_name=$(basename "$app_x86")
+            app_arm="output-arm64/${app_name}"
+            app_out="output-universal/${app_name}"
+
+            if [ ! -d "$app_arm" ]; then
+              echo "Warning: No arm64 counterpart for $app_name, copying x86_64 only"
+              cp -R "$app_x86" "$app_out"
+              continue
+            fi
+
+            # Copy the x86_64 app as a base (preserves structure, plists, resources)
+            cp -R "$app_x86" "$app_out"
+
+            # Find all Mach-O executables/dylibs in the app and lipo them
+            find "$app_x86" -type f | while read f_x86; do
+              rel="${f_x86#$app_x86/}"
+              f_arm="$app_arm/$rel"
+              f_out="$app_out/$rel"
+
+              if [ -f "$f_arm" ] && file "$f_x86" | grep -qE 'Mach-O'; then
+                lipo -create "$f_x86" "$f_arm" -output "$f_out"
+              fi
+            done
+          done
+
+          # Handle any loose binaries/dmg/zip files that aren't .app bundles
+          find output-x86_64 -maxdepth 1 -not -name "*.app" -type f | while read f_x86; do
+            fname=$(basename "$f_x86")
+            f_arm="output-arm64/$fname"
+            if [ -f "$f_arm" ] && file "$f_x86" | grep -qE 'Mach-O'; then
+              lipo -create "$f_x86" "$f_arm" -output "output-universal/$fname"
+            elif [ -f "$f_arm" ]; then
+              cp "$f_x86" "output-universal/$fname"
+            fi
+          done
+
+      - name: Verify universal binaries
+        shell: bash
+        run: |
+          find output-universal -type f | while read f; do
+            if file "$f" | grep -qE 'Mach-O'; then
+              echo "=== $f ==="
+              lipo -info "$f"
+            fi
+          done
+
+      - name: Archive universal artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: "edgetx-cpn-osx-universal-${GITHUB_REF##*/}"
+          path: output-universal
+          retention-days: 15

--- a/.github/workflows/macosx_cpn.yml
+++ b/.github/workflows/macosx_cpn.yml
@@ -262,12 +262,19 @@ jobs:
             local label="$3"
 
             echo "Attaching ${label} DMG at ${mount_point}"
-            if ! hdiutil attach "${dmg_path}" -mountpoint "${mount_point}" -nobrowse -readonly -acceptlicense; then
-              echo "::error::Failed to attach ${label} DMG: ${dmg_path}"
-              echo "${label} DMG imageinfo:"
-              hdiutil imageinfo "${dmg_path}" || true
-              exit 1
+            if hdiutil attach -nobrowse -readonly -acceptlicense -mountpoint "${mount_point}" "${dmg_path}"; then
+              return 0
             fi
+
+            echo "Initial attach failed for ${label}; retrying with piped license acceptance"
+            if yes | hdiutil attach -nobrowse -readonly -acceptlicense -mountpoint "${mount_point}" "${dmg_path}"; then
+              return 0
+            fi
+
+            echo "::error::Failed to attach ${label} DMG: ${dmg_path}"
+            echo "${label} DMG imageinfo:"
+            hdiutil imageinfo "${dmg_path}" || true
+            exit 1
           }
 
           attach_dmg "${X86_DMG}" /tmp/dmg-x86_64 x86_64

--- a/tools/build-companion.sh
+++ b/tools/build-companion.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-. "$SCRIPT_DIR/build-common.sh" 
+. "$SCRIPT_DIR/build-common.sh"
 
 SRCDIR=$1
 OUTDIR=$2
+MACOS_APP_ONLY=${MACOS_APP_ONLY:-0}
 
 if [[ -z ${SRCDIR} ]]; then
   SRCDIR="$(pwd)"
@@ -64,7 +65,7 @@ output_error_log() {
         echo "------------------------------------------"
         cat "$log_file"
         echo "------------------------------------------"
-        
+
         # Also append to master log for aggregation
         {
             echo "=== Error from $log_file ($context) ==="
@@ -125,6 +126,16 @@ run_pipeline() {
             fi
             if ! execute_with_output "📦 Packaging" "cmake_build_parallel native --target ${PACKAGE_TARGET}" "$log_file" "true"; then
                 output_error_log "$log_file" "Final Packaging"
+                return 1
+            fi
+            ;;
+        "final-app")
+            if ! execute_with_output "🔧 Final config" "cmake_build_parallel . --target native-configure ${cmake_opts}" "$log_file" "$show_details"; then
+                output_error_log "$log_file" "Final Configuration"
+                return 1
+            fi
+            if ! execute_with_output "📦 Building companion" "cmake_build_parallel native --target companion ${cmake_opts}" "$log_file" "$show_details"; then
+                output_error_log "$log_file" "$context (Companion Build)"
                 return 1
             fi
             ;;
@@ -236,7 +247,7 @@ for i in "${!simulator_plugins[@]}"; do
     plugin="${simulator_plugins[$i]}"
     current=$((i + 1))
     percent=$((current * 100 / TOTAL))
-    
+
     # For terminal output, put each plugin on its own line for cleaner display
     if [[ -n "$GITHUB_ACTIONS" ]]; then
         printf "::group::%s %-12s [%2d/%2d] %3d%%\n" "$PACKAGE_EMOJI" "$plugin" "$current" "$TOTAL" "$percent"
@@ -290,24 +301,56 @@ else
 fi
 
 error_status=0
-if run_pipeline "final" "final.log" "companion" "true"; then
-    if cp native/$PACKAGE_FILES "${OUTDIR}" 2>/dev/null; then
-        echo "    ✅ All builds completed successfully!"
-        echo "    📁 Package saved to: ${OUTDIR}"
+if [[ "$(uname)" == "Darwin" && "${MACOS_APP_ONLY}" == "1" ]]; then
+    APP_STAGE_DIR="${PWD}/app-stage"
+    if run_pipeline "final-app" "final.log" "companion" "true"; then
+        rm -rf "${APP_STAGE_DIR}"
+        if cmake --install native --prefix "${APP_STAGE_DIR}" --component Runtime >> final.log 2>&1; then
+            APP_BUNDLE_PATH=$(find "${APP_STAGE_DIR}" -maxdepth 1 -name "*.app" -type d -print -quit)
+            if [[ -n "${APP_BUNDLE_PATH}" ]]; then
+                APP_BUNDLE_NAME=$(basename "${APP_BUNDLE_PATH}")
+                APP_ARCHIVE_NAME="${APP_BUNDLE_NAME}.tar.gz"
+                if tar -C "${APP_STAGE_DIR}" -czf "${OUTDIR}/${APP_ARCHIVE_NAME}" "${APP_BUNDLE_NAME}"; then
+                    echo "    ✅ All builds completed successfully!"
+                    echo "    📁 App archive saved to: ${OUTDIR}/${APP_ARCHIVE_NAME}"
+                else
+                    echo "    ❌ Failed to create app archive"
+                    error_status=1
+                fi
+            else
+                echo "    ❌ No .app bundle found in install staging directory"
+                find "${APP_STAGE_DIR}" -maxdepth 3 -print 2>/dev/null || true
+                error_status=1
+            fi
+        else
+            echo "    ❌ Runtime install failed while preparing app bundle"
+            output_error_log "final.log" "Runtime Install"
+            error_status=1
+        fi
     else
-        echo "    ❌ Failed to copy package files to output directory"
-        echo "    📁 Directory Contents:"
-        echo "    ----------------------"
-
-        echo "Contents of native/ directory:"
-        ls -la native/ || echo "native/ directory not found"
-        echo "Looking for files matching: $PACKAGE_FILES"
-        find native/ -name "$PACKAGE_FILES" 2>/dev/null || echo "No matching files found"
+        echo "    ❌ Final app bundle build failed"
         error_status=1
     fi
 else
-    echo "    ❌ Final packaging failed"
-    error_status=1
+    if run_pipeline "final" "final.log" "companion" "true"; then
+        if cp native/$PACKAGE_FILES "${OUTDIR}" 2>/dev/null; then
+            echo "    ✅ All builds completed successfully!"
+            echo "    📁 Package saved to: ${OUTDIR}"
+        else
+            echo "    ❌ Failed to copy package files to output directory"
+            echo "    📁 Directory Contents:"
+            echo "    ----------------------"
+
+            echo "Contents of native/ directory:"
+            ls -la native/ || echo "native/ directory not found"
+            echo "Looking for files matching: $PACKAGE_FILES"
+            find native/ -name "$PACKAGE_FILES" 2>/dev/null || echo "No matching files found"
+            error_status=1
+        fi
+    else
+        echo "    ❌ Final packaging failed"
+        error_status=1
+    fi
 fi
 
 if [[ -n "$GITHUB_ACTIONS" ]]; then


### PR DESCRIPTION
Summary of changes:
- native arm64 and x86 macos builds
- arm64 build requires signing in order to work... i.e. local build can be done with `codesign --force --deep --sign - "EdgeTX Companion 3.0.app"`, but for release it should be done using Apple Developer certificate