### PR TITLE
VALIDATION (do not merge): edgetx-dev:pr-42 native arm64

### DIFF
--- a/.github/workflows/build_fw.yml
+++ b/.github/workflows/build_fw.yml
@@ -20,12 +20,16 @@ on:
 jobs:
   test:
     name: Run tests
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     if: |
       github.event_name != 'pull_request' ||
       !contains(github.event.pull_request.labels.*.name, 'ci: skip-fw')
     strategy:
+      fail-fast: false
       matrix:
+        os:
+          - ubuntu-24.04
+          - ubuntu-24.04-arm
         target:
           - x9dp2019;x9e
           - tx15
@@ -48,7 +52,7 @@ jobs:
           - t15pro
           - pa01
     container:
-      image: ghcr.io/edgetx/edgetx-dev:latest
+      image: ghcr.io/edgetx/edgetx-dev:pr-42
       volumes:
         - ${{ github.workspace }}:/src
     steps:
@@ -68,12 +72,16 @@ jobs:
   build:
     name: Run builds
     needs: test
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     if: |
       github.event_name != 'pull_request' ||
       !contains(github.event.pull_request.labels.*.name, 'ci: skip-fw')
     strategy:
+      fail-fast: false
       matrix:
+        os:
+          - ubuntu-24.04
+          - ubuntu-24.04-arm
         target:
           - nv14;el18
           - pl18;pl18ev
@@ -92,7 +100,7 @@ jobs:
           - nb4p;st16
           - tx16smk3;t14;t15pro
     container:
-      image: ghcr.io/edgetx/edgetx-dev:latest
+      image: ghcr.io/edgetx/edgetx-dev:pr-42
       volumes:
         - ${{ github.workspace }}:/src
     steps:
@@ -112,7 +120,7 @@ jobs:
       - name: Upload ${{ matrix.target }}
         uses: actions/upload-artifact@v7
         with:
-          name: firmware-${{ matrix.target }}
+          name: firmware-${{ matrix.target }}-${{ matrix.os }}
           path: |
             fw.json
             LICENSE

--- a/.github/workflows/companion.yml
+++ b/.github/workflows/companion.yml
@@ -92,12 +92,18 @@ jobs:
 
   build-linux:
     name: Linux Companion
-    runs-on: ubuntu-latest
     needs: modules
     if: inputs.target == 'all' || inputs.target == 'linux' || inputs.target == ''
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-24.04
+          - ubuntu-24.04-arm
+    runs-on: ${{ matrix.os }}
 
     container:
-      image: ghcr.io/edgetx/edgetx-dev:latest
+      image: ghcr.io/edgetx/edgetx-dev:pr-42
       volumes:
         - ${{ github.workspace }}:/src
 
@@ -117,7 +123,7 @@ jobs:
       - name: Setup and Build
         uses: ./.github/actions/build_companion
         with:
-          os: 'linux'
+          os: ${{ matrix.os == 'ubuntu-24.04-arm' && 'linux-arm64' || 'linux-amd64' }}
 
   build-macos:
     name: macOS Companion

--- a/companion/targets/linux/CPackLinuxDeploy.cmake.in
+++ b/companion/targets/linux/CPackLinuxDeploy.cmake.in
@@ -1,8 +1,20 @@
 execute_process(COMMAND @CMAKE_MAKE_PROGRAM@ DESTDIR=@APPIMAGE_DIR@ install
-                WORKING_DIRECTORY @CMAKE_BINARY_DIR@)
+                WORKING_DIRECTORY @CMAKE_BINARY_DIR@
+                RESULT_VARIABLE _install_result
+                OUTPUT_VARIABLE _install_output
+                ERROR_VARIABLE _install_error)
+message(STATUS "DIAG: install result=${_install_result}")
+message(STATUS "DIAG: install output=${_install_output}")
+message(STATUS "DIAG: install error=${_install_error}")
 
 # This is done by cmake install target
 # setup Companion application
 # add -v0 to linuxdeploy for debug info
-execute_process(COMMAND env LDAI_NO_APPSTREAM=1 @LINUXDEPLOY_APP@ --appdir @APPIMAGE_DIR@ -e @COMPANION_NAME@ -e @SIMULATOR_NAME@ -d @COMPANION_DESKTOP_FILE@ --custom-apprun @CMAKE_BINARY_DIR@/AppDir/AppRun --plugin qt --output appimage
-                WORKING_DIRECTORY @CMAKE_BINARY_DIR@)
+execute_process(COMMAND env LDAI_NO_APPSTREAM=1 @LINUXDEPLOY_APP@ --appdir @APPIMAGE_DIR@ -e @COMPANION_NAME@ -e @SIMULATOR_NAME@ -d @COMPANION_DESKTOP_FILE@ --custom-apprun @CMAKE_BINARY_DIR@/AppDir/AppRun --plugin qt --output appimage -v1
+                WORKING_DIRECTORY @CMAKE_BINARY_DIR@
+                RESULT_VARIABLE _ld_result
+                OUTPUT_VARIABLE _ld_output
+                ERROR_VARIABLE _ld_error)
+message(STATUS "DIAG: linuxdeploy result=${_ld_result}")
+message(STATUS "DIAG: linuxdeploy output=${_ld_output}")
+message(STATUS "DIAG: linuxdeploy error=${_ld_error}")

--- a/tools/build-companion.sh
+++ b/tools/build-companion.sh
@@ -122,6 +122,8 @@ elif cp native/$PACKAGE_FILES "${OUTDIR}" 2>/dev/null; then
 else
     echo "    ❌ Failed to copy package files to output directory"
     ls -la native/ || echo "native/ directory not found"
+    echo "    DIAG: tail of packaging log:"
+    grep -A2 "DIAG:" "$LOG_FILE" || tail -100 "$LOG_FILE"
     error_status=1
 fi
 

--- a/tools/build-companion.sh
+++ b/tools/build-companion.sh
@@ -123,7 +123,7 @@ else
     echo "    ❌ Failed to copy package files to output directory"
     ls -la native/ || echo "native/ directory not found"
     echo "    DIAG: tail of packaging log:"
-    grep -A2 "DIAG:" "$LOG_FILE" || tail -100 "$LOG_FILE"
+    tail -200 "$LOG_FILE"
     error_status=1
 fi
 


### PR DESCRIPTION
Temporary branch to validate **EdgeTX/build-edgetx PR #42** (native arm64
`edgetx-dev` image, openssh-client removed) against the workflows that consume it.

Changes (validation only — do not merge):
- `build_fw.yml` (commit-tests + builds) and `companion.yml` build-linux now run on
  **both** `ubuntu-24.04` (amd64) and `ubuntu-24.04-arm` (arm64).
- All point at `ghcr.io/edgetx/edgetx-dev:pr-42` instead of `:latest`.

Goal: confirm `commit-tests.sh` and the Linux Companion build pass inside the new
image on both arches before merging build-edgetx #42 (the failure mode that got
PR #41 reverted).